### PR TITLE
feat: add gemma model support

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ unitorch-infer examples/configs/generation/bart.ini --test_file path/to/test.tsv
 
 | Domain | Models |
 |--------|--------|
-| **Language** | BERT, RoBERTa, XLM-RoBERTa, BART, MBart, LLaMA, Mistral, QWen3 |
+| **Language** | BERT, RoBERTa, XLM-RoBERTa, BART, MBart, LLaMA, Mistral, QWen3, Gemma 4 |
 | **Vision** | BEiT, Swin Transformer, DINOv2, CLIP, SigLIP |
-| **Multimodal** | LLaVA, QWen3-VL, Chinese CLIP |
+| **Multimodal** | LLaVA, QWen3-VL, Gemma 4-VL, Chinese CLIP |
 | **Image Generation** | FLUX (StableFlux), QWenImage |
 | **Video Generation** | Wan (Wan2.2 TI2V-5B) |
 | **Detection** | DETR, Grounding DINO |

--- a/examples/configs/fastapis/flux2.ini
+++ b/examples/configs/fastapis/flux2.ini
@@ -1,0 +1,22 @@
+[core/cli]
+enabled_services = [
+    "core/fastapi/flux2/text2image",
+    "core/fastapi/flux2/editing",
+  ]
+device = cpu
+use_auth_token = True
+health_check_timeout = 300
+
+[core/fastapi/pipeline/flux2/text2image]
+pretrained_name = flux2-klein-4b
+use_auth_token = ${core/cli:use_auth_token}
+device = ${core/cli:device}
+max_sequence_length = 512
+enable_cpu_offload = False
+
+[core/fastapi/pipeline/flux2/editing]
+pretrained_name = flux2-klein-4b
+use_auth_token = ${core/cli:use_auth_token}
+device = ${core/cli:device}
+max_sequence_length = 512
+enable_cpu_offload = False

--- a/examples/configs/fastapis/gemma.ini
+++ b/examples/configs/fastapis/gemma.ini
@@ -1,0 +1,21 @@
+[core/cli]
+enabled_services = [
+    "core/fastapi/gemma",
+    "core/fastapi/gemma_vl",
+  ]
+device = cpu
+health_check_timeout = 1800
+
+[core/fastapi/pipeline/gemma]
+pretrained_name = gemma-4-12b
+device = ${core/cli:device}
+enable_cpu_offload = True
+max_seq_length = 2048
+max_gen_seq_length = 256
+
+[core/fastapi/pipeline/gemma_vl]
+pretrained_name = gemma-4-12b
+device = ${core/cli:device}
+enable_cpu_offload = True
+max_seq_length = 2048
+max_gen_seq_length = 256

--- a/examples/configs/generation/gemma.ini
+++ b/examples/configs/generation/gemma.ini
@@ -1,0 +1,66 @@
+[core/cli]
+task_name = core/task/supervised
+from_ckpt_dir = ./cache
+cache_dir = ./cache
+train_file = ./train.tsv
+dev_file = ./dev.tsv
+test_file = ./test.tsv
+
+# model
+[core/model/generation/gemma]
+pretrained_name = gemma-4-12b
+max_gen_seq_length = 512
+
+# dataset
+[core/dataset/ast]
+names = ['encode', 'decode']
+
+[core/dataset/ast/train]
+data_files = ${core/cli:train_file}
+preprocess_functions = ['core/process/gemma/generation(encode, decode)']
+
+[core/dataset/ast/dev]
+data_files = ${core/cli:dev_file}
+preprocess_functions = ['core/process/gemma/generation/inputs(encode)', 'core/process/gemma/generation/labels(decode)']
+
+[core/dataset/ast/test]
+names = ['encode']
+data_files = ${core/cli:test_file}
+preprocess_functions = ['core/process/gemma/generation/inputs(encode)']
+
+# process
+[core/process/gemma]
+pretrained_name = gemma-4-12b
+max_seq_length = 2048
+max_gen_seq_length = 512
+
+[core/writer/csv]
+escapechar = \
+
+# optim
+[core/optim/adamw]
+learning_rate = 0.00005
+
+# scheduler
+[core/scheduler/linear_warmup]
+num_warmup_rate = 0.001
+
+# task
+[core/task/supervised]
+model = core/model/generation/gemma
+optim = core/optim/adamw
+scheduler = core/scheduler/linear_warmup
+dataset = core/dataset/ast
+loss_fn = core/loss/lm
+score_fn = core/score/bleu
+monitor_fns = ['core/score/bleu', 'core/score/rouge1', 'core/score/rouge2', 'core/score/rougel']
+output_header = ['encode']
+postprocess_fn = core/postprocess/gemma/detokenize
+writer = core/writer/csv
+
+from_ckpt_dir = ${core/cli:from_ckpt_dir}
+to_ckpt_dir = ${core/cli:cache_dir}
+output_path = ${core/cli:cache_dir}/output.txt
+train_batch_size = 1
+dev_batch_size = 1
+test_batch_size = 1

--- a/examples/configs/generation/gemma.lora.ini
+++ b/examples/configs/generation/gemma.lora.ini
@@ -1,0 +1,66 @@
+[core/cli]
+task_name = core/task/supervised
+from_ckpt_dir = ./cache
+cache_dir = ./cache
+train_file = ./train.tsv
+dev_file = ./dev.tsv
+test_file = ./test.tsv
+
+# model
+[core/model/generation/peft/lora/gemma]
+pretrained_name = gemma-4-12b
+max_gen_seq_length = 512
+
+# dataset
+[core/dataset/ast]
+names = ['encode', 'decode']
+
+[core/dataset/ast/train]
+data_files = ${core/cli:train_file}
+preprocess_functions = ['core/process/gemma/generation(encode, decode)']
+
+[core/dataset/ast/dev]
+data_files = ${core/cli:dev_file}
+preprocess_functions = ['core/process/gemma/generation/inputs(encode)', 'core/process/gemma/generation/labels(decode)']
+
+[core/dataset/ast/test]
+names = ['encode']
+data_files = ${core/cli:test_file}
+preprocess_functions = ['core/process/gemma/generation/inputs(encode)']
+
+# process
+[core/process/gemma]
+pretrained_name = gemma-4-12b
+max_seq_length = 2048
+max_gen_seq_length = 512
+
+[core/writer/csv]
+escapechar = \
+
+# optim
+[core/optim/adamw]
+learning_rate = 0.0001
+
+# scheduler
+[core/scheduler/linear_warmup]
+num_warmup_rate = 0.001
+
+# task
+[core/task/supervised]
+model = core/model/generation/peft/lora/gemma
+optim = core/optim/adamw
+scheduler = core/scheduler/linear_warmup
+dataset = core/dataset/ast
+loss_fn = core/loss/lm
+score_fn = core/score/bleu
+monitor_fns = ['core/score/bleu', 'core/score/rouge1', 'core/score/rouge2', 'core/score/rougel']
+output_header = ['encode']
+postprocess_fn = core/postprocess/gemma/detokenize
+writer = core/writer/csv
+
+from_ckpt_dir = ${core/cli:from_ckpt_dir}
+to_ckpt_dir = ${core/cli:cache_dir}
+output_path = ${core/cli:cache_dir}/output.txt
+train_batch_size = 1
+dev_batch_size = 1
+test_batch_size = 1

--- a/examples/configs/generation/gemma_vl.ini
+++ b/examples/configs/generation/gemma_vl.ini
@@ -1,0 +1,66 @@
+[core/cli]
+task_name = core/task/supervised
+from_ckpt_dir = ./cache
+cache_dir = ./cache
+train_file = ./train.tsv
+dev_file = ./dev.tsv
+test_file = ./test.tsv
+
+# model
+[core/model/generation/gemma_vl]
+pretrained_name = gemma-4-12b
+max_gen_seq_length = 512
+
+# dataset
+[core/dataset/ast]
+names = ['encode', 'image', 'decode']
+
+[core/dataset/ast/train]
+data_files = ${core/cli:train_file}
+preprocess_functions = ['core/process/gemma_vl/generation(encode, image, decode)']
+
+[core/dataset/ast/dev]
+data_files = ${core/cli:dev_file}
+preprocess_functions = ['core/process/gemma_vl/generation/inputs(encode, image)', 'core/process/gemma_vl/generation/labels(decode)']
+
+[core/dataset/ast/test]
+names = ['encode', 'image']
+data_files = ${core/cli:test_file}
+preprocess_functions = ['core/process/gemma_vl/generation/inputs(encode, image)']
+
+# process
+[core/process/gemma_vl]
+pretrained_name = gemma-4-12b
+max_seq_length = 2048
+max_gen_seq_length = 512
+
+[core/writer/csv]
+escapechar = \
+
+# optim
+[core/optim/adamw]
+learning_rate = 0.00005
+
+# scheduler
+[core/scheduler/linear_warmup]
+num_warmup_rate = 0.001
+
+# task
+[core/task/supervised]
+model = core/model/generation/gemma_vl
+optim = core/optim/adamw
+scheduler = core/scheduler/linear_warmup
+dataset = core/dataset/ast
+loss_fn = core/loss/lm
+score_fn = core/score/bleu
+monitor_fns = ['core/score/bleu', 'core/score/rouge1', 'core/score/rouge2', 'core/score/rougel']
+output_header = ['encode']
+postprocess_fn = core/postprocess/gemma_vl/detokenize
+writer = core/writer/csv
+
+from_ckpt_dir = ${core/cli:from_ckpt_dir}
+to_ckpt_dir = ${core/cli:cache_dir}
+output_path = ${core/cli:cache_dir}/output.txt
+train_batch_size = 1
+dev_batch_size = 1
+test_batch_size = 1

--- a/examples/fastapis.ini
+++ b/examples/fastapis.ini
@@ -1,5 +1,7 @@
 [core/cli]
 enabled_services = [
+    "core/fastapi/gemma",
+    "core/fastapi/gemma_vl",
     "core/fastapi/qwen3",
     "core/fastapi/qwen3_vl",
     "core/fastapi/flux2/text2image",
@@ -13,6 +15,16 @@ use_auth_token = True
 health_check_timeout = 300
 
 # pipeline
+[core/fastapi/pipeline/gemma]
+pretrained_name = gemma-4-12b
+device = ${core/cli:device}
+enable_cpu_offload = True
+
+[core/fastapi/pipeline/gemma_vl]
+pretrained_name = gemma-4-12b
+device = ${core/cli:device}
+enable_cpu_offload = True
+
 [core/fastapi/pipeline/qwen3]
 device = ${core/cli:device}
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -24,6 +24,7 @@ nav:
       - DinoV2: models/dinov2.md
       - DPT: models/dpt.md
       - Diffusers: models/diffusers.md
+      - Gemma: models/gemma.md
       - GroundingDino: models/grounding_dino.md
       - Kolors: models/kolors.md
       - Llama: models/llama.md
@@ -88,6 +89,7 @@ nav:
       - DinoV2: cli/models/dinov2.md
       - DPT: cli/models/dpt.md
       - Diffusers: cli/models/diffusers.md
+      - Gemma: cli/models/gemma.md
       - GroundingDino: cli/models/grounding_dino.md
       - Kolors: cli/models/kolors.md
       - Llama: cli/models/llama.md

--- a/reports/gemma_model_support_report.md
+++ b/reports/gemma_model_support_report.md
@@ -16,8 +16,8 @@ This report covers the Gemma integration work completed on branch `feat/gemma-mo
 - Date: 2026-06-04
 - Repo: `/home/decu/my/unitorch`
 - Branch: `feat/gemma-model-support`
-- Final commit: `TBD_AFTER_COMMIT`
-- PR: `TBD_AFTER_PR`
+- Feature commit: `1b979fe61e9203e3e8f6a6e04d513c1ddd35bef0`
+- PR: `https://github.com/fuliucansheng/unitorch/pull/35`
 - Python: `3.10.18`
 - PyTorch: `2.10.0+cu128`
 - Transformers: `5.7.0`

--- a/reports/gemma_model_support_report.md
+++ b/reports/gemma_model_support_report.md
@@ -1,0 +1,372 @@
+# Gemma Model Support Report
+
+## Scope
+
+This report covers the Gemma integration work completed on branch `feat/gemma-model-support` in `/home/decu/my/unitorch`.
+
+- Text generation support for `google/gemma-4-12B`
+- Vision-language generation support for `google/gemma-4-12B`
+- CLI model/process registration
+- FastAPI `generate` support
+- `unitorch-infer` smoke validation
+- Training smoke validation for full fine-tune and LoRA
+
+## Environment
+
+- Date: 2026-06-04
+- Repo: `/home/decu/my/unitorch`
+- Branch: `feat/gemma-model-support`
+- Final commit: `TBD_AFTER_COMMIT`
+- PR: `TBD_AFTER_PR`
+- Python: `3.10.18`
+- PyTorch: `2.10.0+cu128`
+- Transformers: `5.7.0`
+- GPU: `NVIDIA RTX A6000` x2, `49140 MiB` each
+- Driver: `570.153.02`
+
+## Checkpoint And Cache
+
+- Required cache path: `UNITORCH_CACHE=/data/decu/.cache`
+- `/data` was already at `100%` usage, so the downloaded Gemma cache entries were relocated behind symlinks:
+  - `/data/decu/.cache/models--google--gemma-4-12B -> /home/decu/.cache/hf-relocated/models--google--gemma-4-12B`
+  - `/data/decu/.cache/.locks/models--google--gemma-4-12B -> /home/decu/.cache/hf-relocated/.locks/models--google--gemma-4-12B`
+- Hugging Face auth state:
+  - `token_present=True`
+  - `whoami=fuliucansheng`
+  - `google/gemma-4-12B private=False`
+  - `google/gemma-4-12B gated=False`
+- Resolved checkpoint revision: `0c9850654599d822abc394e06d35e86e2435cffc`
+- Snapshot files verified:
+  - `config.json`
+  - `model.safetensors`
+  - `processor_config.json`
+  - `tokenizer.json`
+  - `tokenizer_config.json`
+
+## Implementation Summary
+
+- Added explicit Gemma tokenizer/process/model support without using Hugging Face AutoClasses inside this repository.
+- Added Gemma text generation model support.
+- Added Gemma vision-language generation support.
+- Added Gemma LoRA text generation support.
+- Added CLI model registrations, FastAPI registrations, example configs, docs, and registration tests.
+- Fixed runtime issues discovered during real-checkpoint validation:
+  - Greedy decode path no longer assumes `sequences_scores` exists.
+  - Gemma dtype resolution now correctly honors `torch.bfloat16`.
+  - Text-only Gemma paths drop incompatible vision/audio towers so the 12B checkpoint loads as expected.
+  - VLM path uses a custom encoder-free Gemma 12B vision tower that maps checkpoint `vision_embedder.*` weights into generation.
+  - Custom Gemma VLM tower now aligns runtime dtypes and returns a FastAPI/Transformers-compatible dataclass output.
+  - Earlier implementation fixes already included in this branch:
+    - VLM prompt/image placeholder expansion fix
+    - biasless `LayerNorm` init fix
+
+## Files Added Or Updated
+
+- Model code:
+  - `src/unitorch/models/gemma/`
+  - `src/unitorch/models/peft/modeling_gemma.py`
+- CLI code:
+  - `src/unitorch/cli/models/gemma/`
+  - `src/unitorch/cli/models/peft/modeling_gemma.py`
+  - `src/unitorch/cli/fastapis/gemma.py`
+  - `src/unitorch/cli/fastapis/gemma_vl.py`
+- Registry updates:
+  - `src/unitorch/models/__init__.py`
+  - `src/unitorch/models/peft/__init__.py`
+  - `src/unitorch/cli/models/__init__.py`
+  - `src/unitorch/cli/models/peft/__init__.py`
+  - `src/unitorch/cli/fastapis/__init__.py`
+- Examples/docs/tests:
+  - `examples/configs/generation/gemma.ini`
+  - `examples/configs/generation/gemma.lora.ini`
+  - `examples/configs/generation/gemma_vl.ini`
+  - `examples/configs/fastapis/gemma.ini`
+  - `examples/fastapis.ini`
+  - `wiki/models/gemma.md`
+  - `wiki/cli/models/gemma.md`
+  - `wiki/cli/fastapis.md`
+  - `wiki/models/peft.md`
+  - `wiki/cli/models/peft.md`
+  - `README.md`
+  - `mkdocs.yml`
+  - `tests/cli/test_gemma_registration.py`
+
+## Validation Summary
+
+| Area | Result | Notes |
+| --- | --- | --- |
+| `pytest tests/cli/test_gemma_registration.py -q` | Pass | `9 passed` |
+| `python3 -m compileall ...` | Pass | New Gemma model/CLI/FastAPI files compiled |
+| Text pipeline smoke | Pass | Real checkpoint load `99%`, `bfloat16`, output returned |
+| VLM pipeline smoke | Pass | Real checkpoint load `99%`, image input path exercised |
+| `unitorch-infer` text | Pass | Output: `The capital of Germany is -> Berlin.` |
+| `unitorch-infer` VLM | Pass | Output produced from image input path |
+| FastAPI text `/generate` | Pass | HTTP 200 via `TestClient` |
+| FastAPI VLM `/generate` | Pass | HTTP 200 via `TestClient` with query + file upload |
+| Training e2e | Pass | 6-layer truncated config, checkpoint saved |
+| Training LoRA | Pass | 6-layer truncated config, LoRA checkpoint saved |
+| Training checkpoint reload | Pass | e2e and LoRA checkpoints reloaded successfully |
+
+## Commands And Key Outputs
+
+### Registration / compile checks
+
+```bash
+python3 -m pytest tests/cli/test_gemma_registration.py -q
+python3 -m compileall \
+  src/unitorch/models/gemma \
+  src/unitorch/models/peft/modeling_gemma.py \
+  src/unitorch/cli/models/gemma \
+  src/unitorch/cli/models/peft/modeling_gemma.py \
+  src/unitorch/cli/fastapis/gemma.py \
+  src/unitorch/cli/fastapis/gemma_vl.py
+```
+
+Observed result:
+
+- `9 passed in 9.02s`
+
+### Low-level text pipeline smoke
+
+Command shape:
+
+```bash
+UNITORCH_CACHE=/data/decu/.cache \
+HF_HUB_OFFLINE=1 \
+UNITORCH_DEBUG=DETAIL \
+CUDA_VISIBLE_DEVICES=1 \
+python3 - <<'PY'
+# GemmaForGenerationPipeline.from_config(...)
+PY
+```
+
+Key observations:
+
+- `GemmaForGenerationPipeline loaded weights (99%)`
+- `model_dtype torch.bfloat16`
+- `device_before cpu`
+- Output sample:
+
+```text
+The capital of France is -> a city of art, culture, and history.
+```
+
+### Low-level VLM pipeline smoke
+
+Command shape:
+
+```bash
+UNITORCH_CACHE=/data/decu/.cache \
+HF_HUB_OFFLINE=1 \
+UNITORCH_DEBUG=DETAIL \
+CUDA_VISIBLE_DEVICES=1 \
+python3 - <<'PY'
+# GemmaVLForGenerationPipeline.from_config(...)
+PY
+```
+
+Key observations:
+
+- `GemmaVLForGenerationPipeline loaded weights (99%)`
+- `model_dtype torch.bfloat16`
+- `device_before cpu`
+- Output sample from `unitorch.png`:
+
+```text
+What is visible in this image? -> What is the main subject of this image ...
+```
+
+The output is not high quality for this smoke image, but the image-conditioned generate path executed successfully with the real checkpoint.
+
+### CLI inference smoke
+
+Text:
+
+```bash
+unitorch-infer examples/configs/generation/gemma.ini \
+  --train_file /tmp/unitorch_gemma_smoke/train.tsv \
+  --dev_file /tmp/unitorch_gemma_smoke/dev.tsv \
+  --test_file /tmp/unitorch_gemma_smoke/test.tsv \
+  --cache_dir /tmp/unitorch_gemma_smoke/infer_text_clean \
+  --from_ckpt_dir /tmp/unitorch_gemma_smoke/infer_text_from \
+  --core/task/supervised@test_batch_size 1 \
+  --core/task/supervised@num_workers 0 \
+  --core/task/supervised@pin_memory False \
+  --core/process/gemma@max_seq_length 64 \
+  --core/process/gemma@max_gen_seq_length 16 \
+  --core/model/generation/gemma@max_gen_seq_length 16
+```
+
+Observed output:
+
+```text
+The capital of Germany is    Berlin.
+```
+
+VLM:
+
+```bash
+unitorch-infer examples/configs/generation/gemma_vl.ini \
+  --train_file /tmp/unitorch_gemma_smoke/train.tsv \
+  --dev_file /tmp/unitorch_gemma_smoke/dev.tsv \
+  --test_file /tmp/unitorch_gemma_smoke/test_vl.tsv \
+  --cache_dir /tmp/unitorch_gemma_smoke/infer_vl \
+  --from_ckpt_dir /tmp/unitorch_gemma_smoke/infer_vl_from \
+  --core/task/supervised@test_batch_size 1 \
+  --core/task/supervised@num_workers 0 \
+  --core/task/supervised@pin_memory False \
+  --core/process/gemma_vl@max_seq_length 256 \
+  --core/process/gemma_vl@max_gen_seq_length 32 \
+  --core/model/generation/gemma_vl@max_gen_seq_length 32
+```
+
+Observed output:
+
+```text
+What text is visible in this image?    2020 2020 2020 2020 2020 2020 2
+```
+
+### FastAPI generate smoke
+
+Text FastAPI:
+
+- `/core/fastapi/gemma/start` -> `start success`
+- `/core/fastapi/gemma/generate` -> HTTP `200`
+- Response sample:
+
+```text
+Rome, and the capital of the Vatican is the Vatican City...
+```
+
+VLM FastAPI:
+
+- `/core/fastapi/gemma_vl/start` -> `start success`
+- `/core/fastapi/gemma_vl/generate` -> HTTP `200`
+- Request format note: `text` must be sent as a query parameter, not multipart form data.
+- Response sample:
+
+```text
+100 100 100 100 100 100 100 100
+```
+
+### Training smoke
+
+#### Why the training config was reduced
+
+The full 48-layer 12B model is too large for a practical full-parameter smoke run on a single 48 GB GPU once optimizer state is included.
+
+I tried smaller truncation points first:
+
+- 1-layer and 2-layer truncation are not good for this checkpoint because Gemma 4 forces the last layer to `full_attention`, which changes projection shapes and drops checkpoint compatibility.
+- The smallest truncation point that preserves the original layer-type pattern is 6 layers, because the checkpoint uses a repeating pattern where every 6th layer is `full_attention`.
+
+Final training smoke therefore used a 6-layer config derived from the real `google/gemma-4-12B` `config.json`:
+
+- `/tmp/unitorch_gemma_smoke/gemma_6layers_config.json`
+
+#### e2e full fine-tune
+
+Command shape:
+
+```bash
+unitorch-train examples/configs/generation/gemma.ini \
+  --train_file /tmp/unitorch_gemma_smoke/train.tsv \
+  --dev_file /tmp/unitorch_gemma_smoke/dev.tsv \
+  --test_file /tmp/unitorch_gemma_smoke/test.tsv \
+  --cache_dir /tmp/unitorch_gemma_smoke/train_e2e_6layers \
+  --from_ckpt_dir /tmp/unitorch_gemma_smoke/train_e2e_6layers_from \
+  --core/model/generation/gemma@config_path /tmp/unitorch_gemma_smoke/gemma_6layers_config.json \
+  --core/model/generation/gemma@pretrained_weight_path /data/decu/.cache/models--google--gemma-4-12B/snapshots/0c9850654599d822abc394e06d35e86e2435cffc/model.safetensors \
+  --core/model/generation/gemma@gradient_checkpointing True \
+  --core/process/gemma@max_seq_length 64 \
+  --core/process/gemma@max_gen_seq_length 16 \
+  --core/model/generation/gemma@max_gen_seq_length 16 \
+  --core/task/supervised@epochs 1 \
+  --core/task/supervised@train_batch_size 1 \
+  --core/task/supervised@dev_batch_size 1 \
+  --core/task/supervised@num_workers 0 \
+  --core/task/supervised@pin_memory False \
+  --core/task/supervised@log_freq 1 \
+  --core/task/supervised@ckpt_freq 1 \
+  --core/task/supervised@save_optimizer False \
+  --core/task/supervised@save_scheduler False \
+  --core/task/supervised@save_checkpoint latest \
+  --core/task/supervised@use_amp False
+```
+
+Observed result:
+
+- `GemmaForGeneration loaded weights (98%)`
+- `epoch 0 step 0: train/loss=15.791667`
+- Checkpoint written:
+  - `/tmp/unitorch_gemma_smoke/train_e2e_6layers/pytorch_model_latest.bin`
+  - Size: `4.5G`
+
+#### LoRA fine-tune
+
+Command shape:
+
+```bash
+unitorch-train examples/configs/generation/gemma.lora.ini \
+  --train_file /tmp/unitorch_gemma_smoke/train.tsv \
+  --dev_file /tmp/unitorch_gemma_smoke/dev.tsv \
+  --test_file /tmp/unitorch_gemma_smoke/test.tsv \
+  --cache_dir /tmp/unitorch_gemma_smoke/train_lora_6layers \
+  --from_ckpt_dir /tmp/unitorch_gemma_smoke/train_lora_6layers_from \
+  --core/model/generation/peft/lora/gemma@config_path /tmp/unitorch_gemma_smoke/gemma_6layers_config.json \
+  --core/model/generation/peft/lora/gemma@pretrained_weight_path /data/decu/.cache/models--google--gemma-4-12B/snapshots/0c9850654599d822abc394e06d35e86e2435cffc/model.safetensors \
+  --core/model/generation/peft/lora/gemma@gradient_checkpointing True \
+  --core/process/gemma@max_seq_length 64 \
+  --core/process/gemma@max_gen_seq_length 16 \
+  --core/model/generation/peft/lora/gemma@max_gen_seq_length 16 \
+  --core/task/supervised@epochs 1 \
+  --core/task/supervised@train_batch_size 1 \
+  --core/task/supervised@dev_batch_size 1 \
+  --core/task/supervised@num_workers 0 \
+  --core/task/supervised@pin_memory False \
+  --core/task/supervised@log_freq 1 \
+  --core/task/supervised@ckpt_freq 1 \
+  --core/task/supervised@save_optimizer False \
+  --core/task/supervised@save_scheduler False \
+  --core/task/supervised@save_checkpoint latest \
+  --core/task/supervised@use_amp False
+```
+
+Observed result:
+
+- `Gemma4ForConditionalGeneration.add_adapter is incompatible with the installed PEFT version; falling back to inject_adapter_in_model().`
+- `GemmaLoraForGeneration loaded weights (64%)`
+- The lower percentage is expected here because the LoRA model state dict includes newly initialized adapter tensors not present in the base checkpoint.
+- Quick accounting on the 6-layer LoRA model:
+  - `total_keys=132`
+  - `loadable=85`
+  - `46` missing keys were `lora_*` adapter weights
+- `epoch 0 step 0: train/loss=12.375000`
+- Checkpoint written:
+  - `/tmp/unitorch_gemma_smoke/train_lora_6layers/pytorch_model_latest.bin`
+  - Size: `5.2M`
+
+### Checkpoint reload validation
+
+After training, both training outputs were loaded back explicitly:
+
+- e2e checkpoint reload:
+  - `GemmaForGeneration loaded weights from /tmp/unitorch_gemma_smoke/train_e2e_6layers/pytorch_model_latest.bin`
+- LoRA checkpoint reload:
+  - `GemmaLoraForGeneration model load weight from checkpoint /tmp/unitorch_gemma_smoke/train_lora_6layers/pytorch_model_latest.bin`
+
+This confirms the produced checkpoints can be reopened by the corresponding unitorch model classes.
+
+## Known Limitations
+
+- The `google/gemma-4-12B` vision path is working end-to-end, but output quality on the smoke image (`unitorch.png`) is weak and repetitive. The image-conditioned generation path is exercised successfully, but the sample output is not strong enough to claim high OCR quality from this one checkpoint/image pair.
+- FastAPI VLM `generate` expects `text` as a query parameter alongside the uploaded image file. Sending `text` as multipart form data returns HTTP `422`.
+- `transformers` emits upstream warnings during these runs:
+  - `torch_dtype` deprecation warning
+  - `early_stopping` ignored for greedy decode
+  - PEFT compatibility warning requiring fallback to `inject_adapter_in_model()`
+
+## Git Hygiene Notes
+
+- No checkpoint, cache directory, generated image/video output, or `/tmp` smoke artifact is intended to be committed.
+- The only files to be committed are source, config, tests, docs, and this report.

--- a/src/unitorch/cli/consoles/fastapi.py
+++ b/src/unitorch/cli/consoles/fastapi.py
@@ -15,12 +15,8 @@ import logging
 import time
 import urllib.error
 import urllib.request
-import uvicorn
 import hashlib
 import unitorch.cli
-from fastapi import FastAPI
-from fastapi.staticfiles import StaticFiles
-from fastapi.middleware.cors import CORSMiddleware
 from unitorch.cli import Config
 from unitorch.cli import (
     import_library,
@@ -209,6 +205,11 @@ def _wait_for_health_check(config, process, log_file, timeout=None):
 
 
 def _run_foreground(config, pid_file):
+    import uvicorn
+    from fastapi import FastAPI
+    from fastapi.staticfiles import StaticFiles
+    from fastapi.middleware.cors import CORSMiddleware
+
     with open(pid_file, "w") as f:
         f.write(str(os.getpid()))
     atexit.register(lambda: os.path.exists(pid_file) and os.remove(pid_file))

--- a/src/unitorch/cli/fastapis/__init__.py
+++ b/src/unitorch/cli/fastapis/__init__.py
@@ -11,6 +11,8 @@ import unitorch.cli.fastapis.bria
 import unitorch.cli.fastapis.clip
 import unitorch.cli.fastapis.detr
 import unitorch.cli.fastapis.dpt
+import unitorch.cli.fastapis.gemma
+import unitorch.cli.fastapis.gemma_vl
 import unitorch.cli.fastapis.grounding_dino
 import unitorch.cli.fastapis.llama
 import unitorch.cli.fastapis.llava

--- a/src/unitorch/cli/fastapis/gemma.py
+++ b/src/unitorch/cli/fastapis/gemma.py
@@ -1,0 +1,334 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import asyncio
+import gc
+import json
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from fastapi import APIRouter
+
+from unitorch.utils import is_remote_url
+from unitorch.models.gemma import GemmaForGeneration as _GemmaForGeneration
+from unitorch.models.gemma import GemmaProcessor
+from unitorch.utils import nested_dict_value
+from unitorch.cli import config_defaults_init, config_defaults_method
+from unitorch.cli import Config, GenericFastAPI
+from unitorch.cli import cached_path, register_fastapi
+from unitorch.cli.models.gemma import (
+    pretrained_gemma_extensions_infos,
+    resolve_pretrained_gemma_path,
+)
+
+
+class GemmaForGenerationPipeline(_GemmaForGeneration):
+    def __init__(
+        self,
+        config_path: str,
+        tokenizer_file: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+        weight_path: Optional[Union[str, List[str]]] = None,
+        state_dict: Optional[Dict[str, Any]] = None,
+        enable_cpu_offload: Optional[bool] = True,
+        device: Optional[Union[str, int]] = "cpu",
+    ):
+        super().__init__(config_path=config_path)
+        self.processor = GemmaProcessor(
+            tokenizer_file=tokenizer_file,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        self._device = "cpu" if device == "cpu" else int(device)
+        self.from_pretrained(weight_path, state_dict=state_dict)
+        self._enable_cpu_offload = enable_cpu_offload
+        if not self._enable_cpu_offload and self._device != "cpu":
+            self.to(device=self._device)
+        self.eval()
+
+    @classmethod
+    @config_defaults_init("core/fastapi/pipeline/gemma")
+    def from_config(
+        cls,
+        config,
+        pretrained_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        tokenizer_file: Optional[str] = None,
+        pretrained_weight_path: Optional[str] = None,
+        device: Optional[str] = None,
+        **kwargs,
+    ):
+        config.set_default_section("core/fastapi/pipeline/gemma")
+        pretrained_name = pretrained_name or config.getoption(
+            "pretrained_name", "gemma-4-12b"
+        )
+
+        config_path = config_path or config.getoption("config_path", None)
+        if config_path is None:
+            config_path = resolve_pretrained_gemma_path(pretrained_name, "config")
+        else:
+            config_path = cached_path(config_path)
+
+        tokenizer_file = tokenizer_file or config.getoption("tokenizer_file", None)
+        if tokenizer_file is None:
+            tokenizer_file = resolve_pretrained_gemma_path(pretrained_name, "tokenizer")
+        else:
+            tokenizer_file = cached_path(tokenizer_file)
+
+        tokenizer_config = config.getoption("tokenizer_config", None)
+        if tokenizer_config is None:
+            tokenizer_config = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "tokenizer_config",
+            )
+        else:
+            tokenizer_config = cached_path(tokenizer_config)
+
+        chat_template = config.getoption("chat_template", None)
+        chat_template = cached_path(chat_template) if chat_template is not None else None
+
+        max_seq_length = config.getoption("max_seq_length", 12800)
+        max_gen_seq_length = config.getoption("max_gen_seq_length", 512)
+        enable_cpu_offload = config.getoption("enable_cpu_offload", True)
+        device = config.getoption("device", "cpu") if device is None else device
+        pretrained_weight_path = pretrained_weight_path or config.getoption(
+            "pretrained_weight_path", None
+        )
+        weight_path = (
+            pretrained_weight_path
+            if pretrained_weight_path is not None
+            else resolve_pretrained_gemma_path(pretrained_name, "weight")
+        )
+        if pretrained_weight_path is not None:
+            weight_path = cached_path(weight_path)
+
+        return cls(
+            config_path=config_path,
+            tokenizer_file=tokenizer_file,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            weight_path=weight_path,
+            enable_cpu_offload=enable_cpu_offload,
+            device=device,
+        )
+
+    @torch.no_grad()
+    @config_defaults_method("core/fastapi/pipeline/gemma")
+    def __call__(
+        self,
+        prompt: str,
+        use_chat_template: Optional[bool] = False,
+        max_seq_length: Optional[int] = 12800,
+        num_beams: Optional[int] = 2,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+        lora_checkpoints: Optional[Union[str, List[str]]] = [],
+        lora_weights: Optional[Union[float, List[float]]] = [],
+        lora_alphas: Optional[Union[float, List[float]]] = [],
+        lora_urls: Optional[Union[str, List[str]]] = [],
+        lora_files: Optional[Union[str, List[str]]] = [],
+    ):
+        if self._enable_cpu_offload:
+            self.to(self._device)
+
+        if use_chat_template:
+            prompt = self.processor.chat_template(messages=json.loads(prompt))
+
+        inputs = self.processor.generation_inputs(
+            text=prompt,
+            max_seq_length=max_seq_length,
+        )
+        inputs = {k: v.unsqueeze(0) if v is not None else v for k, v in inputs.items()}
+        inputs = {
+            k: v.to(device=self._device) if v is not None else v
+            for k, v in inputs.items()
+        }
+
+        if isinstance(lora_checkpoints, str):
+            lora_checkpoints = [lora_checkpoints]
+        if isinstance(lora_weights, float):
+            lora_weights = [lora_weights]
+        if isinstance(lora_alphas, float):
+            lora_alphas = [lora_alphas]
+        if isinstance(lora_urls, str):
+            lora_urls = [lora_urls]
+        if isinstance(lora_files, str):
+            lora_files = [lora_files]
+
+        assert (
+            len(lora_checkpoints) == len(lora_weights)
+            and len(lora_checkpoints) == len(lora_alphas)
+            and len(lora_checkpoints) == len(lora_urls)
+            and len(lora_checkpoints) == len(lora_files)
+        )
+        processed_lora_files, processed_lora_weights, processed_lora_alphas = [], [], []
+        for ckpt, url, file, weight, alpha in zip(
+            lora_checkpoints, lora_urls, lora_files, lora_weights, lora_alphas
+        ):
+            if ckpt is not None:
+                lora_file = nested_dict_value(
+                    pretrained_gemma_extensions_infos, ckpt, "weight"
+                )
+                processed_lora_files.append(lora_file)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+            elif url is not None and is_remote_url(url):
+                processed_lora_files.append(url)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+            elif file is not None:
+                processed_lora_files.append(file)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+
+        if len(processed_lora_files) > 0:
+            self.load_lora_weights(
+                processed_lora_files,
+                lora_weights=processed_lora_weights,
+                lora_alphas=processed_lora_alphas,
+            )
+
+        outputs = super().generate(
+            input_ids=inputs["input_ids"],
+            attention_mask=inputs.get("attention_mask"),
+            num_beams=num_beams,
+            decoder_start_token_id=decoder_start_token_id,
+            decoder_end_token_id=decoder_end_token_id,
+            decoder_pad_token_id=decoder_pad_token_id,
+            num_return_sequences=num_return_sequences,
+            min_gen_seq_length=min_gen_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            repetition_penalty=repetition_penalty,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        self.unload_lora_weights()
+        decoded = self.processor.detokenize(outputs.sequences)
+        if self._enable_cpu_offload:
+            self.to("cpu")
+            torch.cuda.empty_cache()
+        return decoded[0]
+
+
+@register_fastapi("core/fastapi/gemma")
+class GemmaFastAPI(GenericFastAPI):
+    def __init__(self, config: Config):
+        self.config = config
+        config.set_default_section("core/fastapi/gemma")
+        router = config.getoption("router", "/core/fastapi/gemma")
+        self._pipe = None
+        self._router = APIRouter(prefix=router)
+        self._router.add_api_route("/generate", self.generate, methods=["POST"])
+        self._router.add_api_route("/status", self.status, methods=["GET"])
+        self._router.add_api_route("/start", self.start, methods=["GET"])
+        self._router.add_api_route("/stop", self.stop, methods=["GET"])
+        self._lock = asyncio.Lock()
+
+    @property
+    def router(self):
+        return self._router
+
+    def start(self, pretrained_name: str = "gemma-4-12b"):
+        self._pipe = GemmaForGenerationPipeline.from_config(
+            self.config,
+            pretrained_name=pretrained_name,
+        )
+        return "start success"
+
+    def stop(self):
+        self._pipe.to("cpu")
+        del self._pipe
+        gc.collect()
+        torch.cuda.empty_cache()
+        self._pipe = None
+        return "stop success"
+
+    def status(self):
+        return "running" if self._pipe is not None else "stopped"
+
+    async def generate(
+        self,
+        text: str,
+        use_chat_template: Optional[bool] = False,
+        max_seq_length: Optional[int] = 12800,
+        num_beams: Optional[int] = 2,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+        lora_checkpoints: Optional[Union[str, List[str]]] = [],
+        lora_weights: Optional[Union[float, List[float]]] = [],
+        lora_alphas: Optional[Union[float, List[float]]] = [],
+        lora_urls: Optional[Union[str, List[str]]] = [],
+        lora_files: Optional[Union[str, List[str]]] = [],
+    ):
+        assert self._pipe is not None, "Service not started. Call /start first."
+        async with self._lock:
+            outputs = self._pipe(
+                prompt=text,
+                use_chat_template=use_chat_template,
+                max_seq_length=max_seq_length,
+                num_beams=num_beams,
+                decoder_start_token_id=decoder_start_token_id,
+                decoder_end_token_id=decoder_end_token_id,
+                decoder_pad_token_id=decoder_pad_token_id,
+                num_return_sequences=num_return_sequences,
+                min_gen_seq_length=min_gen_seq_length,
+                max_gen_seq_length=max_gen_seq_length,
+                repetition_penalty=repetition_penalty,
+                no_repeat_ngram_size=no_repeat_ngram_size,
+                early_stopping=early_stopping,
+                length_penalty=length_penalty,
+                num_beam_groups=num_beam_groups,
+                diversity_penalty=diversity_penalty,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                lora_checkpoints=lora_checkpoints,
+                lora_weights=lora_weights,
+                lora_alphas=lora_alphas,
+                lora_urls=lora_urls,
+                lora_files=lora_files,
+            )
+        return outputs

--- a/src/unitorch/cli/fastapis/gemma_vl.py
+++ b/src/unitorch/cli/fastapis/gemma_vl.py
@@ -1,0 +1,364 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import asyncio
+import gc
+import io
+import json
+from typing import Any, Dict, List, Optional, Union
+
+import torch
+from fastapi import APIRouter, File, UploadFile
+from PIL import Image
+
+from unitorch.utils import is_remote_url
+from unitorch.models.gemma import GemmaVLForGeneration as _GemmaVLForGeneration
+from unitorch.models.gemma import GemmaVLProcessor
+from unitorch.utils import nested_dict_value
+from unitorch.cli import config_defaults_init, config_defaults_method
+from unitorch.cli import Config, GenericFastAPI
+from unitorch.cli import cached_path, register_fastapi
+from unitorch.cli.models.gemma import (
+    pretrained_gemma_extensions_infos,
+    resolve_pretrained_gemma_path,
+)
+
+
+class GemmaVLForGenerationPipeline(_GemmaVLForGeneration):
+    def __init__(
+        self,
+        config_path: str,
+        tokenizer_file: str,
+        processor_config_path: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+        weight_path: Optional[Union[str, List[str]]] = None,
+        state_dict: Optional[Dict[str, Any]] = None,
+        enable_cpu_offload: Optional[bool] = True,
+        device: Optional[Union[str, int]] = "cpu",
+    ):
+        super().__init__(config_path=config_path)
+        self.processor = GemmaVLProcessor(
+            tokenizer_file=tokenizer_file,
+            processor_config_path=processor_config_path,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        self._device = "cpu" if device == "cpu" else int(device)
+        self.from_pretrained(weight_path, state_dict=state_dict)
+        self._enable_cpu_offload = enable_cpu_offload
+        if not self._enable_cpu_offload and self._device != "cpu":
+            self.to(device=self._device)
+        self.eval()
+
+    @classmethod
+    @config_defaults_init("core/fastapi/pipeline/gemma_vl")
+    def from_config(
+        cls,
+        config,
+        pretrained_name: Optional[str] = None,
+        config_path: Optional[str] = None,
+        tokenizer_file: Optional[str] = None,
+        pretrained_weight_path: Optional[str] = None,
+        device: Optional[str] = None,
+        **kwargs,
+    ):
+        config.set_default_section("core/fastapi/pipeline/gemma_vl")
+        pretrained_name = pretrained_name or config.getoption(
+            "pretrained_name", "gemma-4-12b"
+        )
+
+        config_path = config_path or config.getoption("config_path", None)
+        if config_path is None:
+            config_path = resolve_pretrained_gemma_path(pretrained_name, "config")
+        else:
+            config_path = cached_path(config_path)
+
+        tokenizer_file = tokenizer_file or config.getoption("tokenizer_file", None)
+        if tokenizer_file is None:
+            tokenizer_file = resolve_pretrained_gemma_path(pretrained_name, "tokenizer")
+        else:
+            tokenizer_file = cached_path(tokenizer_file)
+
+        processor_config_path = config.getoption("processor_config_path", None)
+        if processor_config_path is None:
+            processor_config_path = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "processor_config",
+            )
+        else:
+            processor_config_path = cached_path(processor_config_path)
+
+        tokenizer_config = config.getoption("tokenizer_config", None)
+        if tokenizer_config is None:
+            tokenizer_config = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "tokenizer_config",
+            )
+        else:
+            tokenizer_config = cached_path(tokenizer_config)
+
+        chat_template = config.getoption("chat_template", None)
+        chat_template = cached_path(chat_template) if chat_template is not None else None
+
+        max_seq_length = config.getoption("max_seq_length", 12800)
+        max_gen_seq_length = config.getoption("max_gen_seq_length", 512)
+        enable_cpu_offload = config.getoption("enable_cpu_offload", True)
+        device = config.getoption("device", "cpu") if device is None else device
+        pretrained_weight_path = pretrained_weight_path or config.getoption(
+            "pretrained_weight_path", None
+        )
+        weight_path = (
+            pretrained_weight_path
+            if pretrained_weight_path is not None
+            else resolve_pretrained_gemma_path(pretrained_name, "weight")
+        )
+        if pretrained_weight_path is not None:
+            weight_path = cached_path(weight_path)
+
+        return cls(
+            config_path=config_path,
+            tokenizer_file=tokenizer_file,
+            processor_config_path=processor_config_path,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            weight_path=weight_path,
+            enable_cpu_offload=enable_cpu_offload,
+            device=device,
+        )
+
+    @torch.no_grad()
+    @config_defaults_method("core/fastapi/pipeline/gemma_vl")
+    def __call__(
+        self,
+        prompt: str,
+        images: Optional[Union[Image.Image, List[Image.Image]]] = None,
+        use_chat_template: Optional[bool] = False,
+        max_seq_length: Optional[int] = 12800,
+        num_beams: Optional[int] = 2,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+        lora_checkpoints: Optional[Union[str, List[str]]] = [],
+        lora_weights: Optional[Union[float, List[float]]] = [],
+        lora_alphas: Optional[Union[float, List[float]]] = [],
+        lora_urls: Optional[Union[str, List[str]]] = [],
+        lora_files: Optional[Union[str, List[str]]] = [],
+    ):
+        if self._enable_cpu_offload:
+            self.to(self._device)
+
+        if use_chat_template:
+            prompt = self.processor.chat_template(messages=json.loads(prompt))
+
+        inputs = self.processor.generation_inputs(
+            text=prompt,
+            images=images,
+            max_seq_length=max_seq_length,
+        )
+        inputs = {
+            k: v.unsqueeze(0) if v is not None and v.dim() < 4 else v
+            for k, v in inputs.items()
+        }
+        inputs = {
+            k: v.to(device=self._device) if v is not None else v
+            for k, v in inputs.items()
+        }
+
+        if isinstance(lora_checkpoints, str):
+            lora_checkpoints = [lora_checkpoints]
+        if isinstance(lora_weights, float):
+            lora_weights = [lora_weights]
+        if isinstance(lora_alphas, float):
+            lora_alphas = [lora_alphas]
+        if isinstance(lora_urls, str):
+            lora_urls = [lora_urls]
+        if isinstance(lora_files, str):
+            lora_files = [lora_files]
+
+        assert (
+            len(lora_checkpoints) == len(lora_weights)
+            and len(lora_checkpoints) == len(lora_alphas)
+            and len(lora_checkpoints) == len(lora_urls)
+            and len(lora_checkpoints) == len(lora_files)
+        )
+        processed_lora_files, processed_lora_weights, processed_lora_alphas = [], [], []
+        for ckpt, url, file, weight, alpha in zip(
+            lora_checkpoints, lora_urls, lora_files, lora_weights, lora_alphas
+        ):
+            if ckpt is not None:
+                lora_file = nested_dict_value(
+                    pretrained_gemma_extensions_infos, ckpt, "weight"
+                )
+                processed_lora_files.append(lora_file)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+            elif url is not None and is_remote_url(url):
+                processed_lora_files.append(url)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+            elif file is not None:
+                processed_lora_files.append(file)
+                processed_lora_weights.append(weight)
+                processed_lora_alphas.append(alpha)
+
+        if len(processed_lora_files) > 0:
+            self.load_lora_weights(
+                processed_lora_files,
+                lora_weights=processed_lora_weights,
+                lora_alphas=processed_lora_alphas,
+            )
+
+        outputs = super().generate(
+            input_ids=inputs["input_ids"],
+            pixel_values=inputs.get("pixel_values"),
+            image_position_ids=inputs.get("image_position_ids"),
+            attention_mask=inputs.get("attention_mask"),
+            mm_token_type_ids=inputs.get("mm_token_type_ids"),
+            num_beams=num_beams,
+            decoder_start_token_id=decoder_start_token_id,
+            decoder_end_token_id=decoder_end_token_id,
+            decoder_pad_token_id=decoder_pad_token_id,
+            num_return_sequences=num_return_sequences,
+            min_gen_seq_length=min_gen_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            repetition_penalty=repetition_penalty,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        self.unload_lora_weights()
+        decoded = self.processor.detokenize(outputs.sequences)
+        if self._enable_cpu_offload:
+            self.to("cpu")
+            torch.cuda.empty_cache()
+        return decoded[0]
+
+
+@register_fastapi("core/fastapi/gemma_vl")
+class GemmaVLFastAPI(GenericFastAPI):
+    def __init__(self, config: Config):
+        self.config = config
+        config.set_default_section("core/fastapi/gemma_vl")
+        router = config.getoption("router", "/core/fastapi/gemma_vl")
+        self._pipe = None
+        self._router = APIRouter(prefix=router)
+        self._router.add_api_route("/generate", self.generate, methods=["POST"])
+        self._router.add_api_route("/status", self.status, methods=["GET"])
+        self._router.add_api_route("/start", self.start, methods=["GET"])
+        self._router.add_api_route("/stop", self.stop, methods=["GET"])
+        self._lock = asyncio.Lock()
+
+    @property
+    def router(self):
+        return self._router
+
+    def start(self, pretrained_name: str = "gemma-4-12b"):
+        self._pipe = GemmaVLForGenerationPipeline.from_config(
+            self.config,
+            pretrained_name=pretrained_name,
+        )
+        return "start success"
+
+    def stop(self):
+        self._pipe.to("cpu")
+        del self._pipe
+        gc.collect()
+        torch.cuda.empty_cache()
+        self._pipe = None
+        return "stop success"
+
+    def status(self):
+        return "running" if self._pipe is not None else "stopped"
+
+    async def generate(
+        self,
+        text: str,
+        image: Optional[UploadFile] = File(default=None),
+        use_chat_template: Optional[bool] = False,
+        max_seq_length: Optional[int] = 12800,
+        num_beams: Optional[int] = 2,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+        lora_checkpoints: Optional[Union[str, List[str]]] = [],
+        lora_weights: Optional[Union[float, List[float]]] = [],
+        lora_alphas: Optional[Union[float, List[float]]] = [],
+        lora_urls: Optional[Union[str, List[str]]] = [],
+        lora_files: Optional[Union[str, List[str]]] = [],
+    ):
+        assert self._pipe is not None, "Service not started. Call /start first."
+
+        pil_image = None
+        if image is not None:
+            content = await image.read()
+            pil_image = Image.open(io.BytesIO(content)).convert("RGB")
+
+        async with self._lock:
+            outputs = self._pipe(
+                prompt=text,
+                images=[pil_image] if pil_image is not None else [],
+                use_chat_template=use_chat_template,
+                max_seq_length=max_seq_length,
+                num_beams=num_beams,
+                decoder_start_token_id=decoder_start_token_id,
+                decoder_end_token_id=decoder_end_token_id,
+                decoder_pad_token_id=decoder_pad_token_id,
+                num_return_sequences=num_return_sequences,
+                min_gen_seq_length=min_gen_seq_length,
+                max_gen_seq_length=max_gen_seq_length,
+                repetition_penalty=repetition_penalty,
+                no_repeat_ngram_size=no_repeat_ngram_size,
+                early_stopping=early_stopping,
+                length_penalty=length_penalty,
+                num_beam_groups=num_beam_groups,
+                diversity_penalty=diversity_penalty,
+                do_sample=do_sample,
+                temperature=temperature,
+                top_k=top_k,
+                top_p=top_p,
+                lora_checkpoints=lora_checkpoints,
+                lora_weights=lora_weights,
+                lora_alphas=lora_alphas,
+                lora_urls=lora_urls,
+                lora_files=lora_files,
+            )
+        return outputs

--- a/src/unitorch/cli/models/__init__.py
+++ b/src/unitorch/cli/models/__init__.py
@@ -89,6 +89,7 @@ import unitorch.cli.models.clip
 import unitorch.cli.models.detr
 import unitorch.cli.models.dinov2
 import unitorch.cli.models.dpt
+import unitorch.cli.models.gemma
 import unitorch.cli.models.grounding_dino
 import unitorch.cli.models.kolors
 import unitorch.cli.models.llama

--- a/src/unitorch/cli/models/gemma/__init__.py
+++ b/src/unitorch/cli/models/gemma/__init__.py
@@ -1,0 +1,47 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from functools import lru_cache
+from typing import Optional
+
+from huggingface_hub import hf_hub_download
+
+from unitorch import get_cache_dir
+
+pretrained_gemma_infos = {
+    "gemma-4-12b": {
+        "repo_id": "google/gemma-4-12B",
+        "revision": "main",
+        "config": "config.json",
+        "tokenizer": "tokenizer.json",
+        "tokenizer_config": "tokenizer_config.json",
+        "processor_config": "processor_config.json",
+        "weight": "model.safetensors",
+    },
+}
+
+pretrained_gemma_extensions_infos = {}
+
+
+@lru_cache(maxsize=None)
+def resolve_pretrained_gemma_path(
+    pretrained_name: str,
+    key: str,
+) -> Optional[str]:
+    info = pretrained_gemma_infos[pretrained_name]
+    filename = info.get(key)
+    if filename is None:
+        return None
+
+    return hf_hub_download(
+        repo_id=info["repo_id"],
+        filename=filename,
+        revision=info.get("revision", "main"),
+        cache_dir=get_cache_dir(),
+    )
+
+
+import unitorch.cli.models.gemma.modeling
+import unitorch.cli.models.gemma.modeling_vl
+import unitorch.cli.models.gemma.processing
+import unitorch.cli.models.gemma.processing_vl

--- a/src/unitorch/cli/models/gemma/modeling.py
+++ b/src/unitorch/cli/models/gemma/modeling.py
@@ -1,0 +1,157 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import List, Optional, Union
+
+import torch
+from torch import autocast
+
+from unitorch.utils import is_bfloat16_available
+from unitorch.models.gemma import GemmaForGeneration as _GemmaForGeneration
+from unitorch.cli import (
+    cached_path,
+    config_defaults_init,
+    config_defaults_method,
+    register_model,
+)
+from unitorch.cli.models import GenerationOutputs, generation_model_decorator
+from unitorch.cli.models.gemma import (
+    pretrained_gemma_extensions_infos,
+    resolve_pretrained_gemma_path,
+)
+
+
+@register_model("core/model/generation/gemma", generation_model_decorator)
+class GemmaForGeneration(_GemmaForGeneration):
+    """Gemma model for text generation."""
+
+    def __init__(
+        self,
+        config_path: str,
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__(
+            config_path=config_path,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+    @classmethod
+    @config_defaults_init("core/model/generation/gemma")
+    def from_config(cls, config, **kwargs):
+        config.set_default_section("core/model/generation/gemma")
+        pretrained_name = config.getoption("pretrained_name", "gemma-4-12b")
+        pretrained_lora_name = config.getoption("pretrained_lora_name", None)
+
+        config_path = config.getoption("config_path", None)
+        if config_path is None:
+            config_path = resolve_pretrained_gemma_path(pretrained_name, "config")
+        else:
+            config_path = cached_path(config_path)
+
+        gradient_checkpointing = config.getoption("gradient_checkpointing", False)
+        inst = cls(
+            config_path=config_path,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+        pretrained_weight_path = config.getoption("pretrained_weight_path", None)
+        weight_path = (
+            pretrained_weight_path
+            if pretrained_weight_path is not None
+            else resolve_pretrained_gemma_path(pretrained_name, "weight")
+        )
+        if pretrained_weight_path is not None:
+            weight_path = cached_path(weight_path)
+        if weight_path is not None:
+            inst.from_pretrained(weight_path)
+
+        pretrained_lora_weight_path = config.getoption(
+            "pretrained_lora_weight_path", None
+        )
+        lora_weight_path = (
+            pretrained_lora_weight_path
+            if pretrained_lora_weight_path is not None
+            else pretrained_gemma_extensions_infos.get(pretrained_lora_name)
+        )
+        if pretrained_lora_weight_path is not None:
+            lora_weight_path = cached_path(lora_weight_path)
+        pretrained_lora_weight = config.getoption("pretrained_lora_weight", 1.0)
+        pretrained_lora_alpha = config.getoption("pretrained_lora_alpha", 32.0)
+        if lora_weight_path is not None:
+            inst.load_lora_weights(
+                lora_weight_path,
+                lora_weights=pretrained_lora_weight,
+                lora_alphas=pretrained_lora_alpha,
+                save_base_state=False,
+            )
+
+        return inst
+
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        outputs = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+        return GenerationOutputs(sequences=outputs)
+
+    @config_defaults_method("core/model/generation/gemma")
+    @torch.no_grad()
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ):
+        outputs = super().generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            num_beams=num_beams,
+            decoder_start_token_id=decoder_start_token_id,
+            decoder_end_token_id=decoder_end_token_id,
+            decoder_pad_token_id=decoder_pad_token_id,
+            num_return_sequences=num_return_sequences,
+            min_gen_seq_length=min_gen_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            repetition_penalty=repetition_penalty,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        return GenerationOutputs(
+            sequences=outputs.sequences,
+            sequences_scores=outputs.sequences_scores,
+        )

--- a/src/unitorch/cli/models/gemma/modeling_vl.py
+++ b/src/unitorch/cli/models/gemma/modeling_vl.py
@@ -1,0 +1,169 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import List, Optional, Union
+
+import torch
+from torch import autocast
+
+from unitorch.utils import is_bfloat16_available
+from unitorch.models.gemma import GemmaVLForGeneration as _GemmaVLForGeneration
+from unitorch.cli import (
+    cached_path,
+    config_defaults_init,
+    config_defaults_method,
+    register_model,
+)
+from unitorch.cli.models import GenerationOutputs, generation_model_decorator
+from unitorch.cli.models.gemma import (
+    pretrained_gemma_extensions_infos,
+    resolve_pretrained_gemma_path,
+)
+
+
+@register_model("core/model/generation/gemma_vl", generation_model_decorator)
+class GemmaVLForGeneration(_GemmaVLForGeneration):
+    """Gemma multimodal model for image-grounded generation."""
+
+    def __init__(
+        self,
+        config_path: str,
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__(
+            config_path=config_path,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+    @classmethod
+    @config_defaults_init("core/model/generation/gemma_vl")
+    def from_config(cls, config, **kwargs):
+        config.set_default_section("core/model/generation/gemma_vl")
+        pretrained_name = config.getoption("pretrained_name", "gemma-4-12b")
+        pretrained_lora_name = config.getoption("pretrained_lora_name", None)
+
+        config_path = config.getoption("config_path", None)
+        if config_path is None:
+            config_path = resolve_pretrained_gemma_path(pretrained_name, "config")
+        else:
+            config_path = cached_path(config_path)
+
+        gradient_checkpointing = config.getoption("gradient_checkpointing", False)
+        inst = cls(
+            config_path=config_path,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+        pretrained_weight_path = config.getoption("pretrained_weight_path", None)
+        weight_path = (
+            pretrained_weight_path
+            if pretrained_weight_path is not None
+            else resolve_pretrained_gemma_path(pretrained_name, "weight")
+        )
+        if pretrained_weight_path is not None:
+            weight_path = cached_path(weight_path)
+        if weight_path is not None:
+            inst.from_pretrained(weight_path)
+
+        pretrained_lora_weight_path = config.getoption(
+            "pretrained_lora_weight_path", None
+        )
+        lora_weight_path = (
+            pretrained_lora_weight_path
+            if pretrained_lora_weight_path is not None
+            else pretrained_gemma_extensions_infos.get(pretrained_lora_name)
+        )
+        if pretrained_lora_weight_path is not None:
+            lora_weight_path = cached_path(lora_weight_path)
+        pretrained_lora_weight = config.getoption("pretrained_lora_weight", 1.0)
+        pretrained_lora_alpha = config.getoption("pretrained_lora_alpha", 32.0)
+        if lora_weight_path is not None:
+            inst.load_lora_weights(
+                lora_weight_path,
+                lora_weights=pretrained_lora_weight,
+                lora_alphas=pretrained_lora_alpha,
+                save_base_state=False,
+            )
+
+        return inst
+
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        mm_token_type_ids: Optional[torch.Tensor] = None,
+    ):
+        outputs = super().forward(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_position_ids=image_position_ids,
+            attention_mask=attention_mask,
+            mm_token_type_ids=mm_token_type_ids,
+        )
+        return GenerationOutputs(sequences=outputs)
+
+    @config_defaults_method("core/model/generation/gemma_vl")
+    @torch.no_grad()
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        mm_token_type_ids: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ):
+        outputs = super().generate(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_position_ids=image_position_ids,
+            attention_mask=attention_mask,
+            mm_token_type_ids=mm_token_type_ids,
+            num_beams=num_beams,
+            decoder_start_token_id=decoder_start_token_id,
+            decoder_end_token_id=decoder_end_token_id,
+            decoder_pad_token_id=decoder_pad_token_id,
+            num_return_sequences=num_return_sequences,
+            min_gen_seq_length=min_gen_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            repetition_penalty=repetition_penalty,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        return GenerationOutputs(
+            sequences=outputs.sequences,
+            sequences_scores=outputs.sequences_scores,
+        )

--- a/src/unitorch/cli/models/gemma/processing.py
+++ b/src/unitorch/cli/models/gemma/processing.py
@@ -1,0 +1,161 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import re
+from typing import Any, Dict, List, Optional
+
+from unitorch.models.gemma import GemmaProcessor as _GemmaProcessor
+from unitorch.cli import cached_path, config_defaults_init, register_process
+from unitorch.cli import WriterOutputs
+from unitorch.cli.models import GenerationOutputs, GenerationTargets, TensorInputs
+from unitorch.cli.models.gemma import (
+    resolve_pretrained_gemma_path,
+)
+
+
+class GemmaProcessor(_GemmaProcessor):
+    """Processor for Gemma decoder-only generation tasks."""
+
+    def __init__(
+        self,
+        tokenizer_file: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+    ):
+        super().__init__(
+            tokenizer_file=tokenizer_file,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+
+    @classmethod
+    @config_defaults_init("core/process/gemma")
+    def from_config(cls, config, **kwargs):
+        config.set_default_section("core/process/gemma")
+        pretrained_name = config.getoption("pretrained_name", "gemma-4-12b")
+
+        tokenizer_file = config.getoption("tokenizer_file", None)
+        if tokenizer_file is None:
+            tokenizer_file = resolve_pretrained_gemma_path(pretrained_name, "tokenizer")
+        else:
+            tokenizer_file = cached_path(tokenizer_file)
+
+        tokenizer_config = config.getoption("tokenizer_config", None)
+        if tokenizer_config is None:
+            tokenizer_config = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "tokenizer_config",
+            )
+        else:
+            tokenizer_config = cached_path(tokenizer_config)
+
+        chat_template = config.getoption("chat_template", None)
+        chat_template = cached_path(chat_template) if chat_template is not None else None
+
+        return {
+            "tokenizer_file": tokenizer_file,
+            "tokenizer_config": tokenizer_config,
+            "chat_template": chat_template,
+        }
+
+    @register_process("core/process/gemma/chat_template")
+    def _chat_template(
+        self,
+        messages: List[Dict[str, Any]],
+    ):
+        return super().chat_template(messages=messages)
+
+    @register_process("core/process/gemma/generation/inputs")
+    def _generation_inputs(
+        self,
+        text: str,
+        max_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation_inputs(
+            text=text,
+            max_seq_length=max_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+        )
+
+    @register_process("core/process/gemma/generation/labels")
+    def _generation_labels(
+        self,
+        text: str,
+        max_gen_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation_labels(
+            text=text,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        return GenerationTargets(
+            refs=outputs.input_ids,
+            masks=outputs.attention_mask,
+        )
+
+    @register_process("core/process/gemma/generation")
+    def _generation(
+        self,
+        text: str,
+        text_pair: str,
+        max_seq_length: Optional[int] = None,
+        max_gen_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation(
+            text=text,
+            text_pair=text_pair,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+        ), GenerationTargets(
+            refs=outputs.input_ids_label,
+            masks=outputs.attention_mask_label,
+        )
+
+    @register_process("core/process/gemma/messages/generation")
+    def _messages_generation(
+        self,
+        messages: List[Dict[str, Any]],
+        max_seq_length: Optional[int] = None,
+    ):
+        outputs = super().messages_generation(
+            messages=messages,
+            max_seq_length=max_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+        ), GenerationTargets(
+            refs=outputs.input_ids_label,
+            masks=outputs.attention_mask_label,
+        )
+
+    @register_process("core/postprocess/gemma/detokenize")
+    def _detokenize(
+        self,
+        outputs: GenerationOutputs,
+    ):
+        results = outputs.to_pandas()
+        assert results.shape[0] == 0 or results.shape[0] == outputs.sequences.shape[0]
+
+        decoded = super().detokenize(sequences=outputs.sequences)
+        cleanup_string = lambda text: re.sub(r"\n", " ", text).strip()
+        if isinstance(decoded[0], list):
+            decoded = [list(map(cleanup_string, sequence)) for sequence in decoded]
+        elif isinstance(decoded[0], str):
+            decoded = list(map(cleanup_string, decoded))
+        else:
+            raise ValueError(
+                f"Unsupported type for Gemma detokenize: {type(decoded[0])}"
+            )
+        results["decoded"] = decoded
+        return WriterOutputs(results)

--- a/src/unitorch/cli/models/gemma/processing_vl.py
+++ b/src/unitorch/cli/models/gemma/processing_vl.py
@@ -1,0 +1,188 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import re
+from typing import Any, Dict, List, Optional, Union
+
+from PIL import Image
+
+from unitorch.models.gemma import GemmaVLProcessor as _GemmaVLProcessor
+from unitorch.cli import cached_path, config_defaults_init, register_process
+from unitorch.cli import WriterOutputs
+from unitorch.cli.models import GenerationOutputs, GenerationTargets, TensorInputs
+from unitorch.cli.models.gemma import resolve_pretrained_gemma_path
+
+
+class GemmaVLProcessor(_GemmaVLProcessor):
+    """Processor for Gemma multimodal generation tasks."""
+
+    def __init__(
+        self,
+        tokenizer_file: str,
+        processor_config_path: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+    ):
+        super().__init__(
+            tokenizer_file=tokenizer_file,
+            processor_config_path=processor_config_path,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+
+    @classmethod
+    @config_defaults_init("core/process/gemma_vl")
+    def from_config(cls, config, **kwargs):
+        config.set_default_section("core/process/gemma_vl")
+        pretrained_name = config.getoption("pretrained_name", "gemma-4-12b")
+
+        tokenizer_file = config.getoption("tokenizer_file", None)
+        if tokenizer_file is None:
+            tokenizer_file = resolve_pretrained_gemma_path(pretrained_name, "tokenizer")
+        else:
+            tokenizer_file = cached_path(tokenizer_file)
+
+        processor_config_path = config.getoption("processor_config_path", None)
+        if processor_config_path is None:
+            processor_config_path = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "processor_config",
+            )
+        else:
+            processor_config_path = cached_path(processor_config_path)
+
+        tokenizer_config = config.getoption("tokenizer_config", None)
+        if tokenizer_config is None:
+            tokenizer_config = resolve_pretrained_gemma_path(
+                pretrained_name,
+                "tokenizer_config",
+            )
+        else:
+            tokenizer_config = cached_path(tokenizer_config)
+
+        chat_template = config.getoption("chat_template", None)
+        chat_template = cached_path(chat_template) if chat_template is not None else None
+
+        return {
+            "tokenizer_file": tokenizer_file,
+            "processor_config_path": processor_config_path,
+            "tokenizer_config": tokenizer_config,
+            "chat_template": chat_template,
+        }
+
+    @register_process("core/process/gemma_vl/chat_template")
+    def _chat_template(
+        self,
+        messages: List[Dict[str, Any]],
+    ):
+        return super().chat_template(messages=messages)
+
+    @register_process("core/process/gemma_vl/generation/inputs")
+    def _generation_inputs(
+        self,
+        text: str,
+        images: Union[Image.Image, str, List[Image.Image], List[str]],
+        max_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation_inputs(
+            text=text,
+            images=images,
+            max_seq_length=max_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+            mm_token_type_ids=outputs.mm_token_type_ids,
+            pixel_values=outputs.pixel_values,
+            image_position_ids=outputs.image_position_ids,
+        )
+
+    @register_process("core/process/gemma_vl/generation/labels")
+    def _generation_labels(
+        self,
+        text: str,
+        max_gen_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation_labels(
+            text=text,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        return GenerationTargets(
+            refs=outputs.input_ids,
+            masks=outputs.attention_mask,
+        )
+
+    @register_process("core/process/gemma_vl/generation")
+    def _generation(
+        self,
+        text: str,
+        images: Union[Image.Image, str, List[Image.Image], List[str]],
+        text_pair: str,
+        max_seq_length: Optional[int] = None,
+        max_gen_seq_length: Optional[int] = None,
+    ):
+        outputs = super().generation(
+            text=text,
+            images=images,
+            text_pair=text_pair,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+            mm_token_type_ids=outputs.mm_token_type_ids,
+            pixel_values=outputs.pixel_values,
+            image_position_ids=outputs.image_position_ids,
+        ), GenerationTargets(
+            refs=outputs.input_ids_label,
+            masks=outputs.attention_mask_label,
+        )
+
+    @register_process("core/process/gemma_vl/messages/generation")
+    def _messages_generation(
+        self,
+        messages: List[Dict[str, Any]],
+        images: Union[Image.Image, str, List[Image.Image], List[str]],
+        max_seq_length: Optional[int] = None,
+    ):
+        outputs = super().messages_generation(
+            messages=messages,
+            images=images,
+            max_seq_length=max_seq_length,
+        )
+        return TensorInputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+            mm_token_type_ids=outputs.mm_token_type_ids,
+            pixel_values=outputs.pixel_values,
+            image_position_ids=outputs.image_position_ids,
+        ), GenerationTargets(
+            refs=outputs.input_ids_label,
+            masks=outputs.attention_mask_label,
+        )
+
+    @register_process("core/postprocess/gemma_vl/detokenize")
+    def _detokenize(
+        self,
+        outputs: GenerationOutputs,
+    ):
+        results = outputs.to_pandas()
+        assert results.shape[0] == 0 or results.shape[0] == outputs.sequences.shape[0]
+
+        decoded = super().detokenize(sequences=outputs.sequences)
+        cleanup_string = lambda text: re.sub(r"\n", " ", text).strip()
+        if isinstance(decoded[0], list):
+            decoded = [list(map(cleanup_string, sequence)) for sequence in decoded]
+        elif isinstance(decoded[0], str):
+            decoded = list(map(cleanup_string, decoded))
+        else:
+            raise ValueError(
+                f"Unsupported type for Gemma detokenize: {type(decoded[0])}"
+            )
+        results["decoded"] = decoded
+        return WriterOutputs(results)

--- a/src/unitorch/cli/models/peft/__init__.py
+++ b/src/unitorch/cli/models/peft/__init__.py
@@ -6,6 +6,7 @@ pretrained_peft_infos = {}
 from unitorch.utils import is_diffusers_available
 
 import unitorch.cli.models.peft.modeling_clip
+import unitorch.cli.models.peft.modeling_gemma
 import unitorch.cli.models.peft.modeling_llama
 import unitorch.cli.models.peft.modeling_llava
 import unitorch.cli.models.peft.modeling_mistral

--- a/src/unitorch/cli/models/peft/modeling_gemma.py
+++ b/src/unitorch/cli/models/peft/modeling_gemma.py
@@ -1,0 +1,173 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import List, Optional, Union
+
+import torch
+from torch import autocast
+
+from unitorch.utils import is_bfloat16_available
+from unitorch.models.peft import GemmaLoraForGeneration as _GemmaLoraForGeneration
+from unitorch.cli import (
+    cached_path,
+    config_defaults_init,
+    config_defaults_method,
+    register_model,
+)
+from unitorch.cli.models import GenerationOutputs, generation_model_decorator
+from unitorch.cli.models.gemma import resolve_pretrained_gemma_path
+
+
+@register_model("core/model/generation/peft/lora/gemma", generation_model_decorator)
+class GemmaLoraForGeneration(_GemmaLoraForGeneration):
+    """Gemma LoRA model for text generation."""
+
+    def __init__(
+        self,
+        config_path: str,
+        lora_r: Optional[int] = 16,
+        lora_alpha: Optional[int] = 32,
+        lora_dropout: Optional[float] = 0.05,
+        fan_in_fan_out: Optional[bool] = False,
+        target_modules: Optional[Union[List[str], str]] = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+        ],
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__(
+            config_path=config_path,
+            lora_r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            fan_in_fan_out=fan_in_fan_out,
+            target_modules=target_modules,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+    @classmethod
+    @config_defaults_init("core/model/generation/peft/lora/gemma")
+    def from_config(cls, config, **kwargs):
+        config.set_default_section("core/model/generation/peft/lora/gemma")
+        pretrained_name = config.getoption("pretrained_name", "gemma-4-12b")
+
+        config_path = config.getoption("config_path", None)
+        if config_path is None:
+            config_path = resolve_pretrained_gemma_path(pretrained_name, "config")
+        else:
+            config_path = cached_path(config_path)
+
+        lora_r = config.getoption("lora_r", 16)
+        lora_alpha = config.getoption("lora_alpha", 32)
+        lora_dropout = config.getoption("lora_dropout", 0.05)
+        fan_in_fan_out = config.getoption("fan_in_fan_out", False)
+        target_modules = config.getoption(
+            "target_modules",
+            ["q_proj", "k_proj", "v_proj", "o_proj"],
+        )
+        gradient_checkpointing = config.getoption("gradient_checkpointing", False)
+
+        inst = cls(
+            config_path=config_path,
+            lora_r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            fan_in_fan_out=fan_in_fan_out,
+            target_modules=target_modules,
+            gradient_checkpointing=gradient_checkpointing,
+        )
+
+        weight_path = []
+        pretrained_weight_path = config.getoption("pretrained_weight_path", None)
+        pretrained_weight_path = (
+            pretrained_weight_path
+            if pretrained_weight_path is not None
+            else resolve_pretrained_gemma_path(pretrained_name, "weight")
+        )
+        if pretrained_weight_path is not None:
+            if isinstance(pretrained_weight_path, str):
+                weight_path.append(cached_path(pretrained_weight_path))
+            else:
+                weight_path.extend(map(cached_path, pretrained_weight_path))
+
+        pretrained_lora_weight_path = config.getoption(
+            "pretrained_lora_weight_path", None
+        )
+        if pretrained_lora_weight_path is not None:
+            weight_path.append(cached_path(pretrained_lora_weight_path))
+
+        if len(weight_path) > 0:
+            inst.from_pretrained(weight_path=weight_path)
+
+        return inst
+
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        outputs = super().forward(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+        )
+        return GenerationOutputs(sequences=outputs)
+
+    @config_defaults_method("core/model/generation/peft/lora/gemma")
+    @torch.no_grad()
+    @autocast(
+        device_type=("cuda" if torch.cuda.is_available() else "cpu"),
+        dtype=(torch.bfloat16 if is_bfloat16_available() else torch.float32),
+    )
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ):
+        outputs = super().generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            num_beams=num_beams,
+            decoder_start_token_id=decoder_start_token_id,
+            decoder_end_token_id=decoder_end_token_id,
+            decoder_pad_token_id=decoder_pad_token_id,
+            num_return_sequences=num_return_sequences,
+            min_gen_seq_length=min_gen_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+            repetition_penalty=repetition_penalty,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            do_sample=do_sample,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )
+        return GenerationOutputs(
+            sequences=outputs.sequences,
+            sequences_scores=outputs.sequences_scores,
+        )

--- a/src/unitorch/models/__init__.py
+++ b/src/unitorch/models/__init__.py
@@ -144,7 +144,8 @@ class GenericModel(nn.Module, CheckpointMixin):
         if isinstance(module, (nn.Linear, nn.Embedding)):
             module.weight.data.normal_(mean=0.0, std=0.02)
         if isinstance(module, nn.LayerNorm):
-            module.bias.data.zero_()
+            if module.bias is not None:
+                module.bias.data.zero_()
             module.weight.data.fill_(1.0)
         if isinstance(module, nn.Linear) and module.bias is not None:
             module.bias.data.zero_()
@@ -180,6 +181,7 @@ import unitorch.models.chinese_clip
 import unitorch.models.clip
 import unitorch.models.dinov2
 import unitorch.models.dpt
+import unitorch.models.gemma
 import unitorch.models.grounding_dino
 import unitorch.models.kolors
 import unitorch.models.llama

--- a/src/unitorch/models/gemma/__init__.py
+++ b/src/unitorch/models/gemma/__init__.py
@@ -1,0 +1,7 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from unitorch.models.gemma.modeling import GemmaForGeneration
+from unitorch.models.gemma.modeling_vl import GemmaVLForGeneration
+from unitorch.models.gemma.processing import GemmaProcessor
+from unitorch.models.gemma.processing_vl import GemmaVLProcessor

--- a/src/unitorch/models/gemma/modeling.py
+++ b/src/unitorch/models/gemma/modeling.py
@@ -1,0 +1,137 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import List, Optional, Union
+
+import torch
+from transformers.models.gemma4 import Gemma4Config, Gemma4ForConditionalGeneration
+
+from unitorch.models import GenericModel, GenericOutputs
+from unitorch.models.peft import PeftWeightLoaderMixin
+
+
+def _get_gemma_dtype(config: Gemma4Config) -> torch.dtype:
+    dtype = getattr(config, "dtype", getattr(config, "torch_dtype", "float32"))
+    if isinstance(dtype, torch.dtype):
+        return dtype
+
+    dtype = str(dtype).lower().replace("torch.", "")
+    if dtype == "bfloat16":
+        return torch.bfloat16
+    if dtype in ("float16", "half"):
+        return torch.float16
+    return torch.float32
+
+
+def _get_gemma_text_config(config_path: str) -> Gemma4Config:
+    config = Gemma4Config.from_json_file(config_path)
+    # The 12B checkpoint is encoder-free for vision/audio. Drop unused towers for text
+    # loading so the checkpoint matches the instantiated architecture.
+    config.vision_config = None
+    config.audio_config = None
+    return config
+
+
+class GemmaForGeneration(GenericModel, PeftWeightLoaderMixin):
+    """
+    Gemma text generation model backed by Gemma4's unified checkpoint.
+    """
+
+    prefix_keys_in_state_dict = {"^(?!model\\.model\\.).*": "model."}
+
+    def __init__(
+        self,
+        config_path: str,
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__()
+        self.config = _get_gemma_text_config(config_path)
+        if gradient_checkpointing:
+            self.config.use_cache = False
+            if getattr(self.config, "text_config", None) is not None:
+                self.config.text_config.use_cache = False
+        self.model = Gemma4ForConditionalGeneration(self.config)
+        if gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+        self.init_weights()
+        self.model.to(dtype=_get_gemma_dtype(self.config))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True,
+        )
+        return outputs.logits
+
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ) -> GenericOutputs:
+        input_seq_length = input_ids.size(1)
+        outputs = self.model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            max_length=max_gen_seq_length + input_seq_length,
+            min_length=min_gen_seq_length + input_seq_length,
+            num_beams=num_beams,
+            do_sample=do_sample,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            repetition_penalty=repetition_penalty,
+            num_return_sequences=num_return_sequences,
+            bos_token_id=decoder_start_token_id,
+            eos_token_id=decoder_end_token_id,
+            pad_token_id=decoder_pad_token_id,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+
+        sequences = outputs.sequences.reshape(
+            -1, num_return_sequences, outputs.sequences.size(-1)
+        )
+        padded = torch.full(
+            (sequences.size(0), num_return_sequences, max_gen_seq_length),
+            fill_value=decoder_pad_token_id,
+            device=sequences.device,
+        )
+        padded[:, :, : sequences.size(-1) - input_seq_length].copy_(
+            sequences[:, :, input_seq_length : sequences.size(-1)]
+        )
+
+        if num_return_sequences == 1:
+            padded = padded.reshape(-1, max_gen_seq_length)
+
+        return GenericOutputs(
+            sequences=padded.long(),
+            sequences_scores=getattr(outputs, "sequences_scores", None),
+        )

--- a/src/unitorch/models/gemma/modeling_vl.py
+++ b/src/unitorch/models/gemma/modeling_vl.py
@@ -1,0 +1,293 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import copy
+from typing import List, Optional, Union
+
+import torch
+import torch.nn as nn
+from transformers.modeling_outputs import BaseModelOutputWithPooling
+from transformers.models.gemma4 import Gemma4Config, Gemma4ForConditionalGeneration
+from transformers.models.gemma4.modeling_gemma4 import Gemma4MultimodalEmbedder
+
+from unitorch.models import GenericModel, GenericOutputs
+from unitorch.models.peft import PeftWeightLoaderMixin
+from unitorch.models.gemma.modeling import _get_gemma_dtype
+
+
+def _reshape_image_inputs(
+    pixel_values: Optional[torch.Tensor],
+    image_position_ids: Optional[torch.Tensor],
+):
+    if pixel_values is not None and pixel_values.dim() == 4:
+        pixel_values = pixel_values.view(
+            -1,
+            pixel_values.size(-2),
+            pixel_values.size(-1),
+        )
+    if image_position_ids is not None and image_position_ids.dim() == 4:
+        image_position_ids = image_position_ids.view(
+            -1,
+            image_position_ids.size(-2),
+            image_position_ids.size(-1),
+        )
+    return pixel_values, image_position_ids
+
+
+class GemmaUnifiedVisionTower(nn.Module):
+    """
+    Encoder-free vision tower used by Gemma 4 12B unified checkpoints.
+    """
+
+    def __init__(
+        self,
+        patch_size: int,
+        pooling_kernel_size: int,
+        hidden_size: int,
+        max_soft_tokens: int = 1120,
+    ):
+        super().__init__()
+        patch_dim = 3 * patch_size**2
+        self.pooling_kernel_size = pooling_kernel_size
+        self.patch_ln1 = nn.LayerNorm(patch_dim * pooling_kernel_size**2)
+        self.patch_dense = nn.Linear(
+            patch_dim * pooling_kernel_size**2,
+            hidden_size,
+        )
+        self.patch_ln2 = nn.LayerNorm(hidden_size)
+        self.pos_embedding = nn.Parameter(
+            torch.zeros(max_soft_tokens, 2, hidden_size)
+        )
+        self.pos_norm = nn.LayerNorm(hidden_size)
+
+    def _pool_image_patches(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+    ):
+        valid_mask = ~(pixel_position_ids == -1).all(dim=-1)
+        if not valid_mask.any():
+            return (
+                pixel_values.new_empty((0, self.patch_dense.in_features)),
+                pixel_position_ids.new_empty((0, 2)),
+            )
+
+        patches = pixel_values[valid_mask]
+        positions = pixel_position_ids[valid_mask]
+        pooled_positions = torch.div(
+            positions,
+            self.pooling_kernel_size,
+            rounding_mode="floor",
+        )
+        num_pooled_x = int(pooled_positions[:, 0].max().item()) + 1
+        cell_ids = pooled_positions[:, 1] * num_pooled_x + pooled_positions[:, 0]
+        num_cells = int(cell_ids.max().item()) + 1
+        expected_num_cells = patches.size(0) // (self.pooling_kernel_size**2)
+        if expected_num_cells != num_cells:
+            raise ValueError(
+                "Gemma unified vision pooling expected contiguous 3x3 patch groups "
+                f"but received {patches.size(0)} patches mapped to {num_cells} cells."
+            )
+
+        local_offsets = torch.remainder(positions, self.pooling_kernel_size)
+        local_ids = local_offsets[:, 1] * self.pooling_kernel_size + local_offsets[:, 0]
+        grouped = patches.new_zeros(
+            (num_cells, self.pooling_kernel_size**2, patches.size(-1))
+        )
+        grouped[cell_ids.long(), local_ids.long()] = patches
+
+        pooled_token_positions = torch.stack(
+            [
+                torch.arange(num_cells, device=positions.device) % num_pooled_x,
+                torch.div(
+                    torch.arange(num_cells, device=positions.device),
+                    num_pooled_x,
+                    rounding_mode="floor",
+                ),
+            ],
+            dim=-1,
+        )
+        return grouped.reshape(num_cells, -1), pooled_token_positions
+
+    def forward(
+        self,
+        pixel_values: torch.Tensor,
+        pixel_position_ids: torch.Tensor,
+        **kwargs,
+    ) -> BaseModelOutputWithPooling:
+        pooled_patches, pooled_positions = [], []
+        for image_patches, image_positions in zip(pixel_values, pixel_position_ids):
+            patches, positions = self._pool_image_patches(image_patches, image_positions)
+            if patches.numel() == 0:
+                continue
+            pooled_patches.append(patches)
+            pooled_positions.append(positions)
+
+        if len(pooled_patches) == 0:
+            hidden_states = pixel_values.new_empty((0, self.patch_dense.out_features))
+            return BaseModelOutputWithPooling(last_hidden_state=hidden_states)
+
+        pooled_patches = torch.cat(pooled_patches, dim=0)
+        pooled_positions = torch.cat(pooled_positions, dim=0)
+        pooled_patches = pooled_patches.to(
+            device=self.patch_ln1.weight.device,
+            dtype=self.patch_ln1.weight.dtype,
+        )
+        pooled_positions = pooled_positions.to(device=self.pos_embedding.device)
+
+        hidden_states = self.patch_ln1(pooled_patches)
+        hidden_states = self.patch_dense(hidden_states)
+        hidden_states = self.patch_ln2(hidden_states)
+
+        pooled_positions = pooled_positions.clamp_(0, self.pos_embedding.size(0) - 1)
+        position_embeddings = (
+            self.pos_embedding[pooled_positions[:, 0], 0]
+            + self.pos_embedding[pooled_positions[:, 1], 1]
+        )
+        position_embeddings = position_embeddings.to(
+            dtype=self.pos_norm.weight.dtype
+        )
+        hidden_states = hidden_states + self.pos_norm(position_embeddings).to(
+            hidden_states.dtype
+        )
+        return BaseModelOutputWithPooling(last_hidden_state=hidden_states)
+
+
+class GemmaVLForGeneration(GenericModel, PeftWeightLoaderMixin):
+    """
+    Gemma vision-language generation model backed by Gemma4's unified checkpoint.
+    """
+
+    prefix_keys_in_state_dict = {"^(?!model\\.model\\.).*": "model."}
+    replace_keys_in_state_dict = {
+        r"model\.model\.vision_embedder\.": "model.model.vision_tower.",
+    }
+
+    def __init__(
+        self,
+        config_path: str,
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__()
+        self.config = Gemma4Config.from_json_file(config_path)
+        self.vision_config = copy.deepcopy(self.config.vision_config)
+        self.config.audio_config = None
+        self.config.vision_config = None
+        if gradient_checkpointing:
+            self.config.use_cache = False
+            if getattr(self.config, "text_config", None) is not None:
+                self.config.text_config.use_cache = False
+        self.model = Gemma4ForConditionalGeneration(self.config)
+        self.model.model.vision_tower = GemmaUnifiedVisionTower(
+            patch_size=self.vision_config.patch_size,
+            pooling_kernel_size=self.vision_config.pooling_kernel_size,
+            hidden_size=self.vision_config.output_proj_dims,
+        )
+        self.model.model.embed_vision = Gemma4MultimodalEmbedder(
+            self.vision_config,
+            self.config.text_config,
+        )
+        if gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+        self.init_weights()
+        self.model.to(dtype=_get_gemma_dtype(self.config))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        mm_token_type_ids: Optional[torch.Tensor] = None,
+    ):
+        pixel_values, image_position_ids = _reshape_image_inputs(
+            pixel_values,
+            image_position_ids,
+        )
+        outputs = self.model(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_position_ids=image_position_ids,
+            attention_mask=attention_mask,
+            mm_token_type_ids=mm_token_type_ids,
+            return_dict=True,
+        )
+        return outputs.logits
+
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        pixel_values: Optional[torch.Tensor] = None,
+        image_position_ids: Optional[torch.Tensor] = None,
+        attention_mask: Optional[torch.Tensor] = None,
+        mm_token_type_ids: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ):
+        input_seq_length = input_ids.size(1)
+        pixel_values, image_position_ids = _reshape_image_inputs(
+            pixel_values,
+            image_position_ids,
+        )
+        outputs = self.model.generate(
+            input_ids=input_ids,
+            pixel_values=pixel_values,
+            image_position_ids=image_position_ids,
+            attention_mask=attention_mask,
+            mm_token_type_ids=mm_token_type_ids,
+            max_length=max_gen_seq_length + input_seq_length,
+            min_length=min_gen_seq_length + input_seq_length,
+            num_beams=num_beams,
+            do_sample=do_sample,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            repetition_penalty=repetition_penalty,
+            num_return_sequences=num_return_sequences,
+            bos_token_id=decoder_start_token_id,
+            eos_token_id=decoder_end_token_id,
+            pad_token_id=decoder_pad_token_id,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+
+        sequences = outputs.sequences.reshape(
+            -1, num_return_sequences, outputs.sequences.size(-1)
+        )
+        padded = torch.full(
+            (sequences.size(0), num_return_sequences, max_gen_seq_length),
+            fill_value=decoder_pad_token_id,
+            device=sequences.device,
+        )
+        padded[:, :, : sequences.size(-1) - input_seq_length].copy_(
+            sequences[:, :, input_seq_length : sequences.size(-1)]
+        )
+
+        if num_return_sequences == 1:
+            padded = padded.reshape(-1, max_gen_seq_length)
+
+        return GenericOutputs(
+            sequences=padded.long(),
+            sequences_scores=getattr(outputs, "sequences_scores", None),
+        )

--- a/src/unitorch/models/gemma/processing.py
+++ b/src/unitorch/models/gemma/processing.py
@@ -1,0 +1,117 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import Any, Dict, List, Optional
+
+from transformers.models.gemma import GemmaTokenizer
+
+from unitorch.models import HfLlmProcessor
+from unitorch.utils import read_json_file
+
+
+def _load_gemma_tokenizer(
+    tokenizer_file: str,
+    tokenizer_config: Optional[str] = None,
+    chat_template: Optional[str] = None,
+) -> GemmaTokenizer:
+    tokenizer_kwargs = read_json_file(tokenizer_config) if tokenizer_config else {}
+    tokenizer = GemmaTokenizer(
+        tokenizer_file=tokenizer_file,
+        **tokenizer_kwargs,
+    )
+    if chat_template:
+        tokenizer.chat_template = read_json_file(chat_template)["chat_template"]
+
+    tokenizer.cls_token = tokenizer.bos_token
+    tokenizer.sep_token = tokenizer.eos_token
+    return tokenizer
+
+
+def _render_message_content(
+    content: Any,
+    image_token: Optional[str] = None,
+) -> str:
+    if isinstance(content, list):
+        parts = []
+        for item in content:
+            if isinstance(item, str):
+                parts.append(item)
+                continue
+            if not isinstance(item, dict):
+                parts.append(str(item))
+                continue
+            item_type = item.get("type")
+            if item_type == "text":
+                parts.append(str(item.get("text", "")))
+            elif item_type == "image":
+                parts.append(image_token or "<|image|>")
+            else:
+                parts.append(str(item.get("text", item.get("content", ""))))
+        return "\n".join(filter(None, map(str.strip, parts))).strip()
+
+    if isinstance(content, dict):
+        if content.get("type") == "image":
+            return image_token or "<|image|>"
+        return str(content.get("text", content.get("content", ""))).strip()
+
+    return str(content).strip()
+
+
+def _fallback_chat_template(
+    messages: List[Dict[str, Any]],
+    image_token: Optional[str] = None,
+) -> str:
+    rendered = []
+    for message in messages:
+        role = str(message.get("role", "user")).strip()
+        content = _render_message_content(
+            message.get("content", ""),
+            image_token=image_token,
+        )
+        rendered.append(f"{role}: {content}" if content else f"{role}:")
+
+    if not messages or messages[-1].get("role") != "assistant":
+        rendered.append("assistant:")
+
+    return "\n".join(rendered).strip()
+
+
+class GemmaProcessor(HfLlmProcessor):
+    """
+    Gemma tokenizer-backed processor for decoder-only generation tasks.
+    """
+
+    def __init__(
+        self,
+        tokenizer_file: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+    ):
+        tokenizer = _load_gemma_tokenizer(
+            tokenizer_file=tokenizer_file,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+        )
+        super().__init__(
+            tokenizer=tokenizer,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+
+    def chat_template(
+        self,
+        messages: List[Dict[str, Any]],
+    ) -> str:
+        if getattr(self.tokenizer, "chat_template", None):
+            return self.tokenizer.apply_chat_template(
+                messages,
+                tokenize=False,
+                add_generation_prompt=True,
+            )
+
+        return _fallback_chat_template(
+            messages,
+            image_token=getattr(self.tokenizer, "image_token", None),
+        )

--- a/src/unitorch/models/gemma/processing_vl.py
+++ b/src/unitorch/models/gemma/processing_vl.py
@@ -1,0 +1,188 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import Any, Dict, List, Optional, Sequence, Union
+
+import torch
+from PIL import Image
+from transformers.models.gemma4 import Gemma4ImageProcessor
+
+from unitorch.models import GenericOutputs
+from unitorch.models.gemma.processing import GemmaProcessor
+
+
+class GemmaVLProcessor(GemmaProcessor):
+    """
+    Gemma processor for multimodal generation with image inputs.
+    """
+
+    def __init__(
+        self,
+        tokenizer_file: str,
+        processor_config_path: str,
+        tokenizer_config: Optional[str] = None,
+        chat_template: Optional[str] = None,
+        max_seq_length: Optional[int] = 12800,
+        max_gen_seq_length: Optional[int] = 512,
+    ):
+        super().__init__(
+            tokenizer_file=tokenizer_file,
+            tokenizer_config=tokenizer_config,
+            chat_template=chat_template,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+
+        self.vision_processor = Gemma4ImageProcessor.from_json_file(
+            processor_config_path
+        )
+        self.image_token = getattr(self.tokenizer, "image_token", "<|image|>")
+        self.boi_token = getattr(self.tokenizer, "boi_token", "<|image>")
+        self.eoi_token = getattr(self.tokenizer, "eoi_token", "<image|>")
+        self.image_token_id = getattr(
+            self.tokenizer,
+            "image_token_id",
+            self.tokenizer.convert_tokens_to_ids(self.image_token),
+        )
+
+    def _create_mm_token_type_ids(
+        self,
+        input_ids: torch.Tensor,
+    ) -> torch.Tensor:
+        mm_token_type_ids = torch.zeros_like(input_ids)
+        mm_token_type_ids[input_ids == self.image_token_id] = 1
+        return mm_token_type_ids
+
+    def processing_images(
+        self,
+        images: Union[Image.Image, str, Sequence[Union[Image.Image, str]]],
+    ):
+        if isinstance(images, (Image.Image, str)):
+            images = [images]
+        images = [
+            image if isinstance(image, Image.Image) else Image.open(image).convert("RGB")
+            for image in images
+        ]
+        return self.vision_processor(images=images, return_tensors="pt")
+
+    def _prepare_text_with_images(
+        self,
+        text: str,
+        num_soft_tokens_per_image: Sequence[int],
+    ) -> str:
+        text = str(text)
+        image_count = len(num_soft_tokens_per_image)
+        soft_token_placeholder = "<|gemma_image_soft_token|>"
+        if image_count > 0 and self.image_token not in text:
+            prefix = " ".join([self.image_token] * image_count)
+            text = f"{prefix}\n{text}".strip()
+
+        image_index = 0
+        while self.image_token in text:
+            if image_index >= image_count:
+                raise ValueError(
+                    "More image placeholders were found in the prompt than image inputs."
+                )
+            replacement = (
+                f"{self.boi_token}"
+                f"{soft_token_placeholder * int(num_soft_tokens_per_image[image_index])}"
+                f"{self.eoi_token}"
+            )
+            text = text.replace(self.image_token, replacement, 1)
+            image_index += 1
+
+        if image_index != image_count:
+            raise ValueError(
+                "The number of image placeholders in the prompt does not match the number of image inputs."
+            )
+
+        return text.replace(soft_token_placeholder, self.image_token)
+
+    def generation_inputs(
+        self,
+        text: str,
+        images: Optional[
+            Union[Image.Image, str, Sequence[Union[Image.Image, str]]]
+        ] = None,
+        max_seq_length: Optional[int] = None,
+    ) -> GenericOutputs:
+        image_inputs = self.processing_images(images) if images else None
+        num_soft_tokens_per_image = (
+            image_inputs["num_soft_tokens_per_image"].tolist() if image_inputs else []
+        )
+        text = self._prepare_text_with_images(text, num_soft_tokens_per_image)
+        text_inputs = super().generation_inputs(
+            text=text,
+            max_seq_length=max_seq_length,
+        )
+        return GenericOutputs(
+            input_ids=text_inputs.input_ids,
+            attention_mask=text_inputs.attention_mask,
+            mm_token_type_ids=self._create_mm_token_type_ids(text_inputs.input_ids),
+            pixel_values=(image_inputs["pixel_values"] if image_inputs else None),
+            image_position_ids=(
+                image_inputs["image_position_ids"] if image_inputs else None
+            ),
+        )
+
+    def generation(
+        self,
+        text: str,
+        images: Optional[
+            Union[Image.Image, str, Sequence[Union[Image.Image, str]]]
+        ],
+        text_pair: str,
+        max_seq_length: Optional[int] = None,
+        max_gen_seq_length: Optional[int] = None,
+    ) -> GenericOutputs:
+        image_inputs = self.processing_images(images) if images else None
+        num_soft_tokens_per_image = (
+            image_inputs["num_soft_tokens_per_image"].tolist() if image_inputs else []
+        )
+        text = self._prepare_text_with_images(text, num_soft_tokens_per_image)
+        text_inputs = super().generation(
+            text=text,
+            text_pair=text_pair,
+            max_seq_length=max_seq_length,
+            max_gen_seq_length=max_gen_seq_length,
+        )
+        return GenericOutputs(
+            input_ids=text_inputs.input_ids,
+            attention_mask=text_inputs.attention_mask,
+            mm_token_type_ids=self._create_mm_token_type_ids(text_inputs.input_ids),
+            pixel_values=(image_inputs["pixel_values"] if image_inputs else None),
+            image_position_ids=(
+                image_inputs["image_position_ids"] if image_inputs else None
+            ),
+            input_ids_label=text_inputs.input_ids_label,
+            attention_mask_label=text_inputs.attention_mask_label,
+        )
+
+    def messages_generation(
+        self,
+        messages: List[Dict[str, Any]],
+        images: Optional[
+            Union[Image.Image, str, Sequence[Union[Image.Image, str]]]
+        ] = None,
+        max_seq_length: Optional[int] = None,
+    ) -> GenericOutputs:
+        while messages and messages[-1]["role"] != "assistant":
+            messages.pop()
+
+        text = self.chat_template(messages[:-1])
+        text_pair = self.chat_template(messages[-1:])
+        outputs = self.generation(
+            text=text,
+            images=images,
+            text_pair=text_pair,
+            max_seq_length=max_seq_length,
+        )
+        return GenericOutputs(
+            input_ids=outputs.input_ids,
+            attention_mask=outputs.attention_mask,
+            mm_token_type_ids=outputs.mm_token_type_ids,
+            pixel_values=outputs.pixel_values,
+            image_position_ids=outputs.image_position_ids,
+            input_ids_label=outputs.input_ids_label,
+            attention_mask_label=outputs.attention_mask_label,
+        )

--- a/src/unitorch/models/peft/__init__.py
+++ b/src/unitorch/models/peft/__init__.py
@@ -220,7 +220,8 @@ class GenericPeftModel(nn.Module, PeftCheckpointMixin):
             module.weight.data.normal_(mean=0.0, std=0.02)
 
         if isinstance(module, nn.LayerNorm):
-            module.bias.data.zero_()
+            if module.bias is not None:
+                module.bias.data.zero_()
             module.weight.data.fill_(1.0)
 
         if isinstance(module, nn.Linear) and module.bias is not None:
@@ -359,6 +360,9 @@ class PeftWeightLoaderMixin(nn.Module):
 from unitorch.models.peft.modeling_clip import (
     ClipLoraForMatching,
     ClipLoraForTextMatching,
+)
+from unitorch.models.peft.modeling_gemma import (
+    GemmaLoraForGeneration,
 )
 from unitorch.models.peft.modeling_llama import (
     LlamaLoraForClassification,

--- a/src/unitorch/models/peft/modeling_gemma.py
+++ b/src/unitorch/models/peft/modeling_gemma.py
@@ -1,0 +1,141 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+from typing import List, Optional, Union
+
+import torch
+from peft import LoraConfig
+from transformers.models.gemma4 import Gemma4ForConditionalGeneration
+
+from unitorch.models import GenericOutputs
+from unitorch.models.gemma.modeling import _get_gemma_dtype, _get_gemma_text_config
+from unitorch.models.peft import GenericPeftModel, add_adapter_compat
+
+
+class GemmaLoraForGeneration(GenericPeftModel):
+    prefix_keys_in_state_dict = {"^(?!model\\.model\\.).*": "model."}
+    replace_keys_in_state_dict = {
+        "q_proj.weight": "q_proj.base_layer.weight",
+        "q_proj.bias": "q_proj.base_layer.bias",
+        "k_proj.weight": "k_proj.base_layer.weight",
+        "k_proj.bias": "k_proj.base_layer.bias",
+        "v_proj.weight": "v_proj.base_layer.weight",
+        "v_proj.bias": "v_proj.base_layer.bias",
+        "o_proj.weight": "o_proj.base_layer.weight",
+        "o_proj.bias": "o_proj.base_layer.bias",
+    }
+
+    def __init__(
+        self,
+        config_path: str,
+        lora_r: Optional[int] = 16,
+        lora_alpha: Optional[int] = 32,
+        lora_dropout: Optional[float] = 0.05,
+        fan_in_fan_out: Optional[bool] = False,
+        target_modules: Optional[Union[List[str], str]] = [
+            "q_proj",
+            "k_proj",
+            "v_proj",
+            "o_proj",
+        ],
+        gradient_checkpointing: Optional[bool] = False,
+    ):
+        super().__init__()
+        self.config = _get_gemma_text_config(config_path)
+        if gradient_checkpointing:
+            self.config.use_cache = False
+            if getattr(self.config, "text_config", None) is not None:
+                self.config.text_config.use_cache = False
+        self.peft_config = LoraConfig(
+            r=lora_r,
+            lora_alpha=lora_alpha,
+            lora_dropout=lora_dropout,
+            fan_in_fan_out=fan_in_fan_out,
+            target_modules=target_modules,
+        )
+        self.model = Gemma4ForConditionalGeneration(self.config)
+        self.model = add_adapter_compat(self.model, self.peft_config)
+        if gradient_checkpointing:
+            self.model.gradient_checkpointing_enable()
+        self.init_weights()
+        self.model.to(dtype=_get_gemma_dtype(self.config))
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+    ):
+        outputs = self.model(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            return_dict=True,
+        )
+        return outputs.logits
+
+    @torch.no_grad()
+    def generate(
+        self,
+        input_ids: torch.Tensor,
+        attention_mask: Optional[torch.Tensor] = None,
+        num_beams: Optional[int] = 5,
+        decoder_start_token_id: Optional[int] = 2,
+        decoder_end_token_id: Optional[Union[int, List[int]]] = 1,
+        decoder_pad_token_id: Optional[int] = 0,
+        num_return_sequences: Optional[int] = 1,
+        min_gen_seq_length: Optional[int] = 0,
+        max_gen_seq_length: Optional[int] = 512,
+        repetition_penalty: Optional[float] = 1.0,
+        no_repeat_ngram_size: Optional[int] = 0,
+        early_stopping: Optional[bool] = True,
+        length_penalty: Optional[float] = 1.0,
+        num_beam_groups: Optional[int] = 1,
+        diversity_penalty: Optional[float] = 0.0,
+        do_sample: Optional[bool] = False,
+        temperature: Optional[float] = 1.0,
+        top_k: Optional[int] = 50,
+        top_p: Optional[float] = 1.0,
+    ):
+        input_seq_length = input_ids.size(1)
+        outputs = self.model.generate(
+            input_ids=input_ids,
+            attention_mask=attention_mask,
+            max_length=max_gen_seq_length + input_seq_length,
+            min_length=min_gen_seq_length + input_seq_length,
+            num_beams=num_beams,
+            do_sample=do_sample,
+            no_repeat_ngram_size=no_repeat_ngram_size,
+            early_stopping=early_stopping,
+            length_penalty=length_penalty,
+            repetition_penalty=repetition_penalty,
+            num_return_sequences=num_return_sequences,
+            bos_token_id=decoder_start_token_id,
+            eos_token_id=decoder_end_token_id,
+            pad_token_id=decoder_pad_token_id,
+            num_beam_groups=num_beam_groups,
+            diversity_penalty=diversity_penalty,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            return_dict_in_generate=True,
+            output_scores=True,
+        )
+
+        sequences = outputs.sequences.reshape(
+            -1, num_return_sequences, outputs.sequences.size(-1)
+        )
+        padded = torch.full(
+            (sequences.size(0), num_return_sequences, max_gen_seq_length),
+            fill_value=decoder_pad_token_id,
+            device=sequences.device,
+        )
+        padded[:, :, : sequences.size(-1) - input_seq_length].copy_(
+            sequences[:, :, input_seq_length : sequences.size(-1)]
+        )
+
+        if num_return_sequences == 1:
+            padded = padded.reshape(-1, max_gen_seq_length)
+
+        return GenericOutputs(
+            sequences=padded.long(),
+            sequences_scores=getattr(outputs, "sequences_scores", None),
+        )

--- a/tests/cli/test_gemma_registration.py
+++ b/tests/cli/test_gemma_registration.py
@@ -1,0 +1,96 @@
+# Copyright (c) FULIUCANSHENG.
+# Licensed under the MIT License.
+
+import pytest
+
+from unitorch.cli import Config
+
+
+def test_gemma_cli_registrations():
+    pytest.importorskip("transformers")
+    pytest.importorskip("peft")
+
+    import unitorch.cli.models.gemma  # noqa: F401
+    import unitorch.cli.models.peft  # noqa: F401
+    from unitorch.cli import registered_model, registered_process
+    from unitorch.cli.models.gemma import pretrained_gemma_infos
+
+    assert "gemma-4-12b" in pretrained_gemma_infos
+    assert "core/model/generation/gemma" in registered_model
+    assert "core/model/generation/gemma_vl" in registered_model
+    assert "core/model/generation/peft/lora/gemma" in registered_model
+    assert "core/process/gemma/generation" in registered_process
+    assert "core/process/gemma/generation/inputs" in registered_process
+    assert "core/process/gemma_vl/generation" in registered_process
+    assert "core/process/gemma_vl/generation/inputs" in registered_process
+
+
+def test_gemma_fastapi_registrations():
+    pytest.importorskip("fastapi")
+
+    import unitorch.cli.fastapis.gemma  # noqa: F401
+    import unitorch.cli.fastapis.gemma_vl  # noqa: F401
+    from unitorch.cli import registered_fastapi
+
+    assert "core/fastapi/gemma" in registered_fastapi
+    assert "core/fastapi/gemma_vl" in registered_fastapi
+
+
+def test_gemma_fastapi_start_uses_config_pretrained(monkeypatch):
+    pytest.importorskip("fastapi")
+
+    import unitorch.cli.fastapis.gemma as gemma_fastapi
+
+    captured = {}
+
+    def fake_from_config(cls, config, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        gemma_fastapi.GemmaForGenerationPipeline,
+        "from_config",
+        classmethod(fake_from_config),
+    )
+
+    fastapi = gemma_fastapi.GemmaFastAPI(Config("examples/configs/fastapis/gemma.ini"))
+    assert fastapi.start() == "start success"
+    assert captured["pretrained_name"] == "gemma-4-12b"
+
+
+def test_gemma_vl_fastapi_start_uses_config_pretrained(monkeypatch):
+    pytest.importorskip("fastapi")
+
+    import unitorch.cli.fastapis.gemma_vl as gemma_vl_fastapi
+
+    captured = {}
+
+    def fake_from_config(cls, config, **kwargs):
+        captured.update(kwargs)
+        return object()
+
+    monkeypatch.setattr(
+        gemma_vl_fastapi.GemmaVLForGenerationPipeline,
+        "from_config",
+        classmethod(fake_from_config),
+    )
+
+    fastapi = gemma_vl_fastapi.GemmaVLFastAPI(
+        Config("examples/configs/fastapis/gemma.ini")
+    )
+    assert fastapi.start() == "start success"
+    assert captured["pretrained_name"] == "gemma-4-12b"
+
+
+@pytest.mark.parametrize(
+    "path",
+    [
+        "examples/configs/generation/gemma.ini",
+        "examples/configs/generation/gemma.lora.ini",
+        "examples/configs/generation/gemma_vl.ini",
+        "examples/configs/fastapis/gemma.ini",
+        "examples/fastapis.ini",
+    ],
+)
+def test_gemma_configs_parse(path):
+    Config(path)

--- a/wiki/cli/fastapis.md
+++ b/wiki/cli/fastapis.md
@@ -56,6 +56,20 @@
 
 ::: unitorch.cli.fastapis.dpt.DPTForDepthEstimationFastAPI
 
+## GemmaFastAPI
+
+!!! tip
+    **`core/fastapi/gemma`** is the section for configuration of GemmaFastAPI.
+
+::: unitorch.cli.fastapis.gemma.GemmaFastAPI
+
+## GemmaVLFastAPI
+
+!!! tip
+    **`core/fastapi/gemma_vl`** is the section for configuration of GemmaVLFastAPI.
+
+::: unitorch.cli.fastapis.gemma_vl.GemmaVLFastAPI
+
 ## GroundingDinoForDetectionFastAPI
 
 !!! tip

--- a/wiki/cli/models/gemma.md
+++ b/wiki/cli/models/gemma.md
@@ -1,0 +1,29 @@
+# unitorch.cli.models.gemma
+
+## GemmaProcessor
+
+!!! tip
+    **`core/process/gemma`** is the section for configuration of GemmaProcessor.
+
+::: unitorch.cli.models.gemma.processing.GemmaProcessor
+
+## GemmaVLProcessor
+
+!!! tip
+    **`core/process/gemma_vl`** is the section for configuration of GemmaVLProcessor.
+
+::: unitorch.cli.models.gemma.processing_vl.GemmaVLProcessor
+
+## GemmaForGeneration
+
+!!! tip
+    **`core/model/generation/gemma`** is the section for configuration of GemmaForGeneration.
+
+::: unitorch.cli.models.gemma.modeling.GemmaForGeneration
+
+## GemmaVLForGeneration
+
+!!! tip
+    **`core/model/generation/gemma_vl`** is the section for configuration of GemmaVLForGeneration.
+
+::: unitorch.cli.models.gemma.modeling_vl.GemmaVLForGeneration

--- a/wiki/cli/models/peft.md
+++ b/wiki/cli/models/peft.md
@@ -7,6 +7,13 @@
 
 ::: unitorch.cli.models.peft.modeling_clip.ClipLoraForMatching
 
+## GemmaLoraForGeneration
+
+!!! tip
+    **`core/model/generation/peft/lora/gemma`** is the section for configuration of GemmaLoraForGeneration.
+
+::: unitorch.cli.models.peft.modeling_gemma.GemmaLoraForGeneration
+
 ## LlamaLoraForClassification
 
 !!! tip

--- a/wiki/models/gemma.md
+++ b/wiki/models/gemma.md
@@ -1,0 +1,17 @@
+# unitorch.models.gemma
+
+## GemmaProcessor
+
+::: unitorch.models.gemma.GemmaProcessor
+
+## GemmaVLProcessor
+
+::: unitorch.models.gemma.GemmaVLProcessor
+
+## GemmaForGeneration
+
+::: unitorch.models.gemma.GemmaForGeneration
+
+## GemmaVLForGeneration
+
+::: unitorch.models.gemma.GemmaVLForGeneration

--- a/wiki/models/peft.md
+++ b/wiki/models/peft.md
@@ -8,6 +8,10 @@
 
 ::: unitorch.models.peft.ClipLoraForTextMatching
 
+## GemmaLoraForGeneration
+
+::: unitorch.models.peft.GemmaLoraForGeneration
+
 ## LlamaLoraForClassification
 
 ::: unitorch.models.peft.LlamaLoraForClassification


### PR DESCRIPTION
## Summary
- add explicit Gemma text, vision-language, and LoRA model support
- wire Gemma through CLI, FastAPI, examples, docs, and registration tests
- include a full validation report at `reports/gemma_model_support_report.md`

## Test Plan
- `python3 -m pytest tests/cli/test_gemma_registration.py -q`
- `python3 -m compileall src/unitorch/models/gemma src/unitorch/models/peft/modeling_gemma.py src/unitorch/cli/models/gemma src/unitorch/cli/models/peft/modeling_gemma.py src/unitorch/cli/fastapis/gemma.py src/unitorch/cli/fastapis/gemma_vl.py`
- real-checkpoint text pipeline smoke with `google/gemma-4-12B`
- real-checkpoint VLM pipeline smoke with `google/gemma-4-12B`
- `unitorch-infer` text smoke
- `unitorch-infer` VLM smoke
- FastAPI `/generate` smoke for text and VLM
- e2e training smoke with a 6-layer truncated config derived from the real checkpoint
- LoRA training smoke with a 6-layer truncated config derived from the real checkpoint
- post-train checkpoint reload smoke for e2e and LoRA

## Report
- `reports/gemma_model_support_report.md`